### PR TITLE
Support for SSL/TLS connections

### DIFF
--- a/lib/kafka_client.ex
+++ b/lib/kafka_client.ex
@@ -6,7 +6,8 @@ defmodule BroadwayKafka.KafkaClient do
            client_id: any,
            group_id: any,
            topics: any,
-           group_config: keyword
+           group_config: keyword,
+           client_config: keyword
          }
 
   @callback init(opts :: any) :: {:ok, config} | {:error, any}

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -28,6 +28,9 @@ defmodule BroadwayKafka.Producer do
     * `:fetch_config` - Optional. A list of options used when fetching messages. See the
       "Fetch config options" section below for a list of all available options.
 
+    * `:client_config` - Optional. A list of options used when creating the client. See the
+      "Client config options" section below for a list of all available options.
+
   ## Group config options
 
   The available options that will be passed to `:brod`'s group coordinator.
@@ -54,6 +57,14 @@ defmodule BroadwayKafka.Producer do
     * `:max_bytes` - Optional. The maximum amount of data to be fetched at a time from a single
       partition. Default is 1048576 (1 MiB). Setting greater values can improve server
       throughput at the cost of more memory consumption.
+
+  ## Client config options
+
+  The available options that will be internally passed to `:brod.start_client/3`.
+
+    * `:ssl` - Optional. A list of options to use when connecting via SSL/TLS. See the
+    [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option) documentation
+    for more information. Default is no ssl options.
 
   > **Note**: Currently, Broadway does not support all options provided by `:brod`. If you
   have a scenario where you need any extra option that is not listed above, please open an

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -8,7 +8,8 @@ defmodule BroadwayKafka.BrodClientTest do
     hosts: [host: 9092],
     topics: ["topic"],
     group_config: [],
-    fetch_config: []
+    fetch_config: [],
+    client_config: []
   ]
 
   describe "validate init options" do
@@ -126,6 +127,28 @@ defmodule BroadwayKafka.BrodClientTest do
       opts = put_in(@opts, [:fetch_config, :max_bytes], 3)
       {:ok, %{fetch_config: fetch_config}} = BrodClient.init(opts)
       assert fetch_config[:max_bytes] == 3
+    end
+
+    test ":ssl is an optional keyword list" do
+      opts = put_in(@opts, [:client_config, :ssl], :an_atom)
+
+      assert BrodClient.init(opts) ==
+               {:error,
+                "expected :ssl to be a keyword list of SSL/TLS client options, got: :an_atom"}
+
+      opts =
+        put_in(@opts, [:client_config, :ssl],
+          cacertfile: "ca.crt",
+          keyfile: "client.key",
+          certfile: "client.crt"
+        )
+
+      assert {:ok,
+              %{
+                client_config: [
+                  ssl: [cacertfile: "ca.crt", keyfile: "client.key", certfile: "client.crt"]
+                ]
+              }} = BrodClient.init(opts)
     end
   end
 end


### PR DESCRIPTION
This adds support for connecting to Kafka via SSL/TLS through
a client configuration. Any options specified through the
`client_config` will be passed to `brod:start_client/3`.

Example usage:

```
Broadway.start_link(__MODULE__,
  name: __MODULE__,
  producer: [
    module: {BroadwayKafka.Producer, [
      hosts: [localhost: 9092],
      group_id: "group_1",
      topics: ["test"],
      client_config: [
        ssl: [
          cacertfile: "ca.crt",
          keyfile: "client.key",
          certfile: "client.crt"
        ]
      ]
    ]},
    concurrency: 10
  ],
  processors: [
    default: [
      concurrency: 10
    ]
  ]
)
```

Resolves #8 