### PR TITLE
Allow boolean for client config ssl option

### DIFF
--- a/lib/brod_client.ex
+++ b/lib/brod_client.ex
@@ -223,6 +223,8 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:max_bytes, value) when not is_integer(value) or value < 1,
     do: validation_error(:max_bytes, "a positive integer", value)
 
+  defp validate_option(:ssl, value) when is_boolean(value), do: {:ok, value}
+
   defp validate_option(:ssl, value) do
     if Keyword.keyword?(value) do
       {:ok, value}

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -75,7 +75,7 @@ defmodule BroadwayKafka.Producer do
 
   The available options that will be internally passed to `:brod.start_client/3`.
 
-    * `:ssl` - Optional. A list of options to use when connecting via SSL/TLS. See the
+    * `:ssl` - Optional. A boolean or a list of options to use when connecting via SSL/TLS. See the
     [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option) documentation
     for more information. Default is no ssl options.
 

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -169,7 +169,7 @@ defmodule BroadwayKafka.BrodClientTest do
       assert fetch_config[:max_bytes] == 3
     end
 
-    test ":ssl is an optional keyword list" do
+    test ":ssl is an optional boolean or keyword list" do
       opts = put_in(@opts, [:client_config, :ssl], :an_atom)
 
       assert BrodClient.init(opts) ==
@@ -188,6 +188,13 @@ defmodule BroadwayKafka.BrodClientTest do
                 client_config: [
                   ssl: [cacertfile: "ca.crt", keyfile: "client.key", certfile: "client.crt"]
                 ]
+              }} = BrodClient.init(opts)
+
+      opts = put_in(@opts, [:client_config, :ssl], true)
+
+      assert {:ok,
+              %{
+                client_config: [ssl: true]
               }} = BrodClient.init(opts)
     end
   end


### PR DESCRIPTION
This PR adds support for passing a boolean to the `:ssl` client config options.
It seems it's [allowed](https://github.com/klarna/brod/blob/bb78a36d1027633f601b04dfbf44e12312c46959/src/brod.erl#L347-L351) by brod and in my use case (connecting to confluent cloud kafka) passing an empty list wasn't enough, I had to be able to pass `true` to it
I also needed the `:sasl` option which I'll add in an additional PR after this gets merged/rejected