### PR TITLE
Add SASL authentication support

### DIFF
--- a/lib/brod_client.ex
+++ b/lib/brod_client.ex
@@ -21,7 +21,8 @@ defmodule BroadwayKafka.BrodClient do
   ]
 
   @supported_client_config_options [
-    :ssl
+    :ssl,
+    :sasl
   ]
 
   @default_receive_interval 2000
@@ -223,6 +224,17 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:max_bytes, value) when not is_integer(value) or value < 1,
     do: validation_error(:max_bytes, "a positive integer", value)
 
+  defp validate_option(:sasl, value) do
+    with {mechanism, username, password}
+         when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
+                is_binary(username) and
+                is_binary(password) <- value do
+      {:ok, value}
+    else
+      _value -> validation_error(:sasl, "a tuple of SASL mechanism, username and password", value)
+    end
+  end
+
   defp validate_option(:ssl, value) do
     if Keyword.keyword?(value) do
       {:ok, value}
@@ -259,6 +271,7 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_client_config(opts) do
     with {:ok, [_ | _] = config} <-
            validate_supported_opts(opts, :client_config, @supported_client_config_options),
+         {:ok, _} <- validate(config, :sasl),
          {:ok, _} <- validate(config, :ssl) do
       {:ok, config}
     end

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -75,6 +75,10 @@ defmodule BroadwayKafka.Producer do
 
   The available options that will be internally passed to `:brod.start_client/3`.
 
+    * `:sasl` - Optional. A a tuple of mechanism which can be `:plain`, `:scram_sha_256` or `:scram_sha_512`, username and password. See the `:brod`'s
+    [`Authentication Support`](https://github.com/klarna/brod#authentication-support) documentation
+    for more information. Default is no sasl options.
+
     * `:ssl` - Optional. A list of options to use when connecting via SSL/TLS. See the
     [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option) documentation
     for more information. Default is no ssl options.

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -169,6 +169,29 @@ defmodule BroadwayKafka.BrodClientTest do
       assert fetch_config[:max_bytes] == 3
     end
 
+    test ":sasl is an optional tuple of SASL mechanism, username and password" do
+      opts = put_in(@opts, [:client_config, :sasl], :an_atom)
+
+      assert BrodClient.init(opts) ==
+               {:error,
+                "expected :sasl to be a tuple of SASL mechanism, username and password, got: :an_atom"}
+
+      opts = put_in(@opts, [:client_config, :sasl], {:an_atom, "username", "password"})
+
+      assert BrodClient.init(opts) ==
+               {:error,
+                "expected :sasl to be a tuple of SASL mechanism, username and password, got: {:an_atom, \"username\", \"password\"}"}
+
+      opts = put_in(@opts, [:client_config, :sasl], {:plain, "username", "password"})
+
+      assert {:ok,
+              %{
+                client_config: [
+                  sasl: {:plain, "username", "password"}
+                ]
+              }} = BrodClient.init(opts)
+    end
+
     test ":ssl is an optional keyword list" do
       opts = put_in(@opts, [:client_config, :ssl], :an_atom)
 


### PR DESCRIPTION
Allows passing SASL credentials to `:brod`'s `client_config`

In my specific use case, I need it to authenticate into the Confluent Cloud