### PR TITLE
Fix resolve begin offset for SSL/SASL

### DIFF
--- a/lib/brod_client.ex
+++ b/lib/brod_client.ex
@@ -122,10 +122,10 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   @impl true
-  def resolve_offset(hosts, topic, partition, current_offset, offset_reset_policy) do
+  def resolve_offset(topic, partition, current_offset, offset_reset_policy, config) do
     policy = offset_reset_policy_value(offset_reset_policy)
 
-    case :brod.resolve_offset(hosts, topic, partition, policy) do
+    case :brod.resolve_offset(config.hosts, topic, partition, policy, config.client_config) do
       {:ok, offset} ->
         if current_offset == :undefined || current_offset > offset do
           offset
@@ -134,7 +134,7 @@ defmodule BroadwayKafka.BrodClient do
         end
 
       {:error, reason} ->
-        raise "cannot resolve begin offset (hosts=#{inspect(hosts)} topic=#{topic} " <>
+        raise "cannot resolve begin offset (hosts=#{inspect(config.hosts)} topic=#{topic} " <>
                 "partition=#{partition}). Reason: #{inspect(reason)}"
     end
   end

--- a/lib/kafka_client.ex
+++ b/lib/kafka_client.ex
@@ -41,11 +41,11 @@ defmodule BroadwayKafka.KafkaClient do
               {:ok, {offset :: integer, [:brod.message()]}} | {:error, any()}
 
   @callback resolve_offset(
-              hosts :: [:brod.endpoint()],
               topic :: binary,
               partition :: integer,
               offset :: integer,
-              offset_reset_policy :: offset_reset_policy()
+              offset_reset_policy :: offset_reset_policy(),
+              config
             ) ::
               offset :: integer | no_return()
 

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -254,11 +254,16 @@ defmodule BroadwayKafka.Producer do
           begin_offset: begin_offset
         ) = assignment
 
-        hosts = state.config.hosts
         offset_reset_policy = state.config[:offset_reset_policy]
 
         offset =
-          state.client.resolve_offset(hosts, topic, partition, begin_offset, offset_reset_policy)
+          state.client.resolve_offset(
+            topic,
+            partition,
+            begin_offset,
+            offset_reset_policy,
+            state.config
+          )
 
         {group_generation_id, topic, partition, offset}
       end)

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -101,7 +101,7 @@ defmodule BroadwayKafka.ProducerTest do
     end
 
     @impl true
-    def resolve_offset(_hosts, _topic, _partition, offset, _offset_reset_policy) do
+    def resolve_offset(_topic, _partition, offset, _offset_reset_policy, _config) do
       offset
     end
   end


### PR DESCRIPTION
Resolves the following issue from comment https://github.com/dashbitco/broadway_kafka/issues/11#issuecomment-586581499 which occurred to my connection too:

```
04:58:21.475 [error] GenServer Consumer.Broadway.Producer_0 terminating
** (RuntimeError) cannot resolve begin offset (hosts=["pkc-m6.us-east-1.aws.confluent.cloud": 9092] topic=test partition=0). Reason: [{{:"pkc-m6.us-east-1.aws.confluent.cloud", 9092}, {{{:kpro_req, #Reference<0.4271768152.1015808001.8234>, :api_versions, 0, false, ""}, :closed}, [{:kpro_lib, :send_and_recv_raw, 4, [file: 'src/kpro_lib.erl', line: 71]}, {:kpro_lib, :send_and_recv, 5, [file: 'src/kpro_lib.erl', line: 82]}, {:kpro_connection, :query_api_versions, 4, [file: 'src/kpro_connection.erl', line: 246]}, {:kpro_connection, :init_connection, 2, [file: 'src/kpro_connection.erl', line: 233]}, {:kpro_connection, :init, 4, [file: 'src/kpro_connection.erl', line: 170]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}]
    (broadway_kafka) lib/brod_client.ex:138: BroadwayKafka.BrodClient.resolve_offset/5
    (broadway_kafka) lib/producer.ex:265: anonymous fn/3 in BroadwayKafka.Producer.handle_info/2
    (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
    (broadway_kafka) lib/producer.ex:254: BroadwayKafka.Producer.handle_info/2
    (broadway) lib/broadway/producer.ex:258: Broadway.Producer.handle_info/2
    (gen_stage) lib/gen_stage.ex:2086: GenStage.noreply_callback/3
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
Last message: {:put_assignments, 11, [{:brod_received_assignment, "test", 0, :undefined}]}
State: %{consumers: [{#PID<0.238.0>, #Reference<0.4271768152.1015808004.6809>}], module: BroadwayKafka.Producer, module_state: %{acks: %{}, allocator_names: {0, [Consumer.Allocator_processor_default], []}, buffer: {[], []}, client: BroadwayKafka.BrodClient, client_id: Consumer.Broadway.Producer_0.Client, config: %{client_config: [ssl: [cacertfile: "./priv/ssl/server.crt", keyfile: "./priv/ssl/server.key", certfile: "./priv/ssl/server.crt"], sasl: {:plain, "##############", "############################"}], fetch_config: %{max_bytes: 10240}, group_config: [offset_commit_policy: :commit_to_kafka_v2, offset_commit_interval_seconds: 1, rejoin_delay_seconds: 2], group_id: "test", hosts: ["pkc-m6.us-east-1.aws.confluent.cloud": 9092], offset_commit_on_ack: true, offset_reset_policy: :latest, receive_interval: 2000, reconnect_timeout: 1000, topics: ["test"]}, demand: 10, group_coordinator: #PID<0.355.0>, receive_interval: 2000, receive_timer: #Reference<0.4271768152.1015808004.6828>, reconnect_timeout: 1000, revoke_caller: nil, shutting_down?: false}, rate_limiting: nil, transformer: nil}
```
```
iex(1)> :brod.resolve_offset(["pkc-m6.us-east-1.aws.confluent.cloud": 9092], "test", 0)                     
{:error,
 [
   {{:"pkc-m6.us-east-1.aws.confluent.cloud", 9092},
    {{{:kpro_req, #Reference<0.3260138594.749207555.138861>, :api_versions, 0,
       false, ""}, :closed},
     [
       {:kpro_lib, :send_and_recv_raw, 4, [file: 'src/kpro_lib.erl', line: 71]},
       {:kpro_lib, :send_and_recv, 5, [file: 'src/kpro_lib.erl', line: 82]},
       {:kpro_connection, :query_api_versions, 4,
        [file: 'src/kpro_connection.erl', line: 246]},
       {:kpro_connection, :init_connection, 2,
        [file: 'src/kpro_connection.erl', line: 233]},
       {:kpro_connection, :init, 4,
        [file: 'src/kpro_connection.erl', line: 170]},
       {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}
     ]}}
 ]}
```

The issue was resolved using the [:brod.resolve_offset/5](https://github.com/klarna/brod/blob/master/src/brod.erl#L848) which passes the SSL/SASL configurations to connect successfully to the cloud:

```
iex(5)> :brod.resolve_offset(["pkc-m6.us-east-1.aws.confluent.cloud": 9092], "test", 0, :latest, client_config)
{:ok, 24}
```