### PR TITLE
Add message headers (available from kafka 0.11) to message.metadata

### DIFF
--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -466,14 +466,21 @@ defmodule BroadwayKafka.Producer do
   end
 
   defp wrap_message(kafka_msg, topic, partition, generation_id) do
-    kafka_message(value: data, offset: offset, key: key, ts: ts) = kafka_msg
+    kafka_message(value: data, offset: offset, key: key, ts: ts, headers: headers) = kafka_msg
 
     ack_data = %{offset: offset}
     ack_ref = {self(), {generation_id, topic, partition}}
 
     message = %Message{
       data: data,
-      metadata: %{topic: topic, partition: partition, offset: offset, key: key, ts: ts},
+      metadata: %{
+        topic: topic,
+        partition: partition,
+        offset: offset,
+        key: key,
+        ts: ts,
+        headers: headers
+      },
       acknowledger: {Acknowledger, ack_ref, ack_data}
     }
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BroadwayKafka.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @description "A Kafka connector for Broadway"
 
   def project do


### PR DESCRIPTION
Kafka now allows to send metadata on headers [key=value] 
It is very useful to handle message versioning, event method, etc.