### PR TITLE
Add support for keywords with binary as key

### DIFF
--- a/lib/brod_client.ex
+++ b/lib/brod_client.ex
@@ -172,7 +172,7 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   defp validate_option(:hosts, value) do
-    if Keyword.keyword?(value) do
+    if supported_hosts?(value) do
       {:ok, value}
     else
       validation_error(:hosts, "a keyword list of host/port pairs", value)
@@ -300,4 +300,10 @@ defmodule BroadwayKafka.BrodClient do
         -1
     end
   end
+
+  defp supported_hosts?([{key, _value} | rest]) when is_binary(key) or is_atom(key),
+    do: supported_hosts?(rest)
+
+  defp supported_hosts?([]), do: true
+  defp supported_hosts?(_other), do: false
 end

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -24,6 +24,9 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = Keyword.put(@opts, :hosts, host: 9092)
       assert {:ok, %{hosts: [host: 9092]}} = BrodClient.init(opts)
+
+      opts = Keyword.put(@opts, :hosts, [{"host", 9092}])
+      assert {:ok, %{hosts: [{"host", 9092}]}} = BrodClient.init(opts)
     end
 
     test ":group_id is a required string" do


### PR DESCRIPTION
Given that `:brod` accepts a keyword list with string as the key `[{"localhost", 9092}]`, I think that we should accept the same format because config keys like `hosts` usually will be coming from an env var as a binary, not as an atom.

```elixir
iex(1)> :brod.start_client([{"localhost", 9092}], :client)

22:59:42.721 [info]  [supervisor: {:local, :brod_sup}, started: [pid: #PID<0.211.0>, id: :client, mfargs: {:brod_client, :start_link, [[{"localhost", 9092}], :client, []]}, restart_type: {:permanent, 10}, shutdown: 5000, child_type: :worker]]
:ok
```