### PR TITLE
Properly indent docs to become source block

### DIFF
--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -13,14 +13,14 @@ defmodule BroadwayKafka.Producer do
       separated HOST:PORT pairs to use for establishing the initial connection to Kafka,
       e.g. [localhost: 9092]. Examples:
 
-        # Keyword
-        [kafka-vm1: 9092, kafka-vm2: 9092, kafka-vm3: 9092]
+          # Keyword
+          [kafka-vm1: 9092, kafka-vm2: 9092, kafka-vm3: 9092]
 
-        # List of tuples
-        [{"kafka-vm1", 9092}, {"kafka-vm2", 9092}, {"kafka-vm3", 9092}]
+          # List of tuples
+          [{"kafka-vm1", 9092}, {"kafka-vm2", 9092}, {"kafka-vm3", 9092}]
 
-        # Single `String.t`
-        "kafka-vm1:9092,kafka-vm2:9092,kafka-vm3:9092"
+          # Single `String.t`
+          "kafka-vm1:9092,kafka-vm2:9092,kafka-vm3:9092"
 
     * `:group_id` - Required. A unique string that identifies the consumer group the producer
       will belong to.


### PR DESCRIPTION
Silly spaces that makes a difference... let's keep the quality of docs on this community high! (or, fixing a mistake I introduced before =/ )

Currently:

![image](https://user-images.githubusercontent.com/376386/94367356-8925c800-00b4-11eb-8a3a-0abcf2834756.png)

With this PR:

![image](https://user-images.githubusercontent.com/376386/94367366-993da780-00b4-11eb-8453-1a9f1f3b565b.png)
