### PR TITLE
Fix/check if pid is alive on assignments revoked

### DIFF
--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -412,7 +412,13 @@ defmodule BroadwayKafka.Producer do
 
   @impl :brod_group_member
   def assignments_revoked(producer_pid) do
-    GenStage.call(producer_pid, :drain_after_revoke, :infinity)
+-    GenStage.call(producer_pid, :drain_after_revoke, :infinity)
++    # If the producer_pid is no longer alive, it means the revoke
++    # is happening due to a shutdown, so ignore it.
++    if Process.alive?(producer_pid) do
++      GenStage.call(producer_pid, :drain_after_revoke, :infinity)
++    end
++
     :ok
   end
 

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -412,13 +412,12 @@ defmodule BroadwayKafka.Producer do
 
   @impl :brod_group_member
   def assignments_revoked(producer_pid) do
--    GenStage.call(producer_pid, :drain_after_revoke, :infinity)
-+    # If the producer_pid is no longer alive, it means the revoke
-+    # is happening due to a shutdown, so ignore it.
-+    if Process.alive?(producer_pid) do
-+      GenStage.call(producer_pid, :drain_after_revoke, :infinity)
-+    end
-+
+    # If the producer_pid is no longer alive, it means the revoke
+    # is happening due to a shutdown, so ignore it.
+    if Process.alive?(producer_pid) do
+      GenStage.call(producer_pid, :drain_after_revoke, :infinity)
+    end
+
     :ok
   end
 

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -415,6 +415,7 @@ defmodule BroadwayKafka.Producer do
     # If the producer_pid is no longer alive, it means the revoke
     # is happening due to a shutdown, so ignore it.
     pid = Process.whereis(producer_pid)
+
     if !is_nil(pid) and Process.alive?(pid) do
       GenStage.call(producer_pid, :drain_after_revoke, :infinity)
     end

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -414,7 +414,8 @@ defmodule BroadwayKafka.Producer do
   def assignments_revoked(producer_pid) do
     # If the producer_pid is no longer alive, it means the revoke
     # is happening due to a shutdown, so ignore it.
-    if Process.alive?(producer_pid) do
+    pid = Process.whereis(producer_pid)
+    if !is_nil(pid) and Process.alive?(pid) do
       GenStage.call(producer_pid, :drain_after_revoke, :infinity)
     end
 


### PR DESCRIPTION
Prevents Genserver crash error if the PID does not exist because the pipeline is being shutdown