### PR TITLE
Add guard clause for assignments_revoked/1

### DIFF
--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -411,9 +411,11 @@ defmodule BroadwayKafka.Producer do
   end
 
   @impl :brod_group_member
+  # If the producer is no longer alive, it means the revoke
+  # is happening due to a shutdown, so ignore it.
   def assignments_revoked(producer_name) when is_atom(producer_name) do
     if producer_pid = Process.whereis(producer_name) do
-      assignments_revoked(producer_pid)
+      GenStage.call(producer_pid, :drain_after_revoke, :infinity)
     end
 
     :ok
@@ -421,8 +423,6 @@ defmodule BroadwayKafka.Producer do
 
   @impl :brod_group_member
   def assignments_revoked(producer_pid) when is_pid(producer_pid) do
-    # If the producer_pid is no longer alive, it means the revoke
-    # is happening due to a shutdown, so ignore it.
     if Process.alive?(producer_pid) do
       GenStage.call(producer_pid, :drain_after_revoke, :infinity)
     end

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -412,22 +412,18 @@ defmodule BroadwayKafka.Producer do
 
   @impl :brod_group_member
   def assignments_revoked(producer_name) when is_atom(producer_name) do
-    # If the producer_pid is no longer alive, it means the revoke
-    # is happening due to a shutdown, so ignore it.
-    producer_pid = Process.whereis(producer_name)
-
-    if !is_nil(producer_pid) and Process.alive?(producer_pid) do
-      GenStage.call(producer_name, :drain_after_revoke, :infinity)
+    if producer_pid = Process.whereis(producer_name) do
+      assignments_revoked(producer_pid)
     end
 
     :ok
   end
 
   @impl :brod_group_member
-  def assignments_revoked(producer_pid) do
+  def assignments_revoked(producer_pid) when is_pid(producer_pid) do
     # If the producer_pid is no longer alive, it means the revoke
     # is happening due to a shutdown, so ignore it.
-    if !is_nil(producer_pid) and Process.alive?(producer_pid) do
+    if Process.alive?(producer_pid) do
       GenStage.call(producer_pid, :drain_after_revoke, :infinity)
     end
 


### PR DESCRIPTION
handle assignments_revoked differently based on if param is pid or pipeline atom name