### PR TITLE
Support acking compacted offsets

### DIFF
--- a/test/acknowledger_test.exs
+++ b/test/acknowledger_test.exs
@@ -44,6 +44,12 @@ defmodule BroadwayKafka.AcknowledgerTest do
     assert {false, nil, ack} = Ack.update_current_offset(ack, @foo, [13, 14])
     assert {false, 16, ack} = Ack.update_current_offset(ack, @foo, [10, 11, 12, 15, 16, 18, 19])
     assert {true, 19, _} = Ack.update_current_offset(ack, @foo, [17])
+
+    # Compaction skips offset at the beginning
+    ack = Ack.update_last_offset(@ack, @foo, 20)
+    assert {false, nil, ack} = Ack.update_current_offset(ack, @foo, [13, 14])
+    assert {false, 16, ack} = Ack.update_current_offset(ack, @foo, [10, 15, 16, 18, 19])
+    assert {true, 19, _} = Ack.update_current_offset(ack, @foo, [17])
   end
 
   test "all_drained?" do


### PR DESCRIPTION
Not sure how we should handle compacted offsets, current implementation basically requires that the next offset be a `current + 1` but with compaction that will not be the case.  How do we ack messages that were compacted away while still ensuring that we are not skipping over non-compacted offsets?