### PR TITLE
Support for max_wait_time in fetch config

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -17,7 +17,8 @@ defmodule BroadwayKafka.BrodClient do
 
   @supported_fetch_config_options [
     :min_bytes,
-    :max_bytes
+    :max_bytes,
+    :max_wait_time
   ]
 
   @supported_client_config_options [
@@ -234,6 +235,9 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:max_bytes, value) when not is_integer(value) or value < 1,
     do: validation_error(:max_bytes, "a positive integer", value)
 
+  defp validate_option(:max_wait_time, value) when not is_integer(value) or value < 1,
+    do: validation_error(:max_wait_time, "a positive integer", value)
+
   defp validate_option(:sasl, value) do
     with {mechanism, username, password}
          when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
@@ -278,7 +282,8 @@ defmodule BroadwayKafka.BrodClient do
     with {:ok, [_ | _] = config} <-
            validate_supported_opts(opts, :fetch_config, @supported_fetch_config_options),
          {:ok, _} <- validate(config, :min_bytes),
-         {:ok, _} <- validate(config, :max_bytes) do
+         {:ok, _} <- validate(config, :max_bytes),
+         {:ok, _} <- validate(config, :max_wait_time) do
       {:ok, config}
     end
   end

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -80,6 +80,9 @@ defmodule BroadwayKafka.Producer do
       partition. Default is 1048576 (1 MiB). Setting greater values can improve server
       throughput at the cost of more memory consumption.
 
+    * `:max_wait_time` - Optional. Time in millisecond. Max number of milliseconds allowed for the broker to collect
+    `min_bytes' of messages in fetch response. Default is 1000ms.
+
   ## Client config options
 
   The available options that will be internally passed to `:brod.start_client/3`.

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -183,6 +183,20 @@ defmodule BroadwayKafka.BrodClientTest do
       assert fetch_config[:max_bytes] == 3
     end
 
+    test ":max_wait_time is optional non-negative integer" do
+      opts = put_in(@opts, [:fetch_config, :max_wait_time], :an_atom)
+
+      assert BrodClient.init(opts) ==
+               {:error, "expected :max_wait_time to be a positive integer, got: :an_atom"}
+
+      {:ok, %{fetch_config: fetch_config}} = BrodClient.init(@opts)
+      assert not Map.has_key?(fetch_config, :max_wait_time)
+
+      opts = put_in(@opts, [:fetch_config, :max_wait_time], 3)
+      {:ok, %{fetch_config: fetch_config}} = BrodClient.init(opts)
+      assert fetch_config[:max_wait_time] == 3
+    end
+
     test ":sasl is an optional tuple of SASL mechanism, username and password" do
       opts = put_in(@opts, [:client_config, :sasl], :an_atom)
 


### PR DESCRIPTION
**Description**

`max_wait_time` defaults 1000ms, which is not ideal for every applications out there, ref: [brod_utils.erl:342](https://github.com/kafka4beam/brod/blob/master/src/brod_utils.erl#L342). 
