### PR TITLE
Use Broadway public API instead of private on change_topics

### DIFF
--- a/lib/broadway_kafka.ex
+++ b/lib/broadway_kafka.ex
@@ -24,7 +24,7 @@ defmodule BroadwayKafka do
 
   defp each_producer(server, fun) when is_function(fun, 1) do
     server
-    |> Broadway.Server.producer_names()
+    |> Broadway.producer_names()
     |> Enum.each(fun)
   end
 end


### PR DESCRIPTION
I created a new application depending only on BroadwayKafka:
```elixir
  defp deps do
    [
      {:broadway_kafka, "~> 0.2"}
    ]
  end
```

And mix got me Broadway 0.6.2 installed.  

The current implementation of `change_topics` relies on Broadway internal API `Broadway.Server`, which was renamed to `Broadway.Topology` from 0.6.2. Due to tht, `BroadwayKafka.change_topics` didn't work.

This PR uses `Broadway` instead of `Broadway.Server`.
