### PR TITLE
Add client_id option to client_config

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -239,8 +239,8 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:max_wait_time, value) when not is_integer(value) or value < 1,
     do: validation_error(:max_wait_time, "a positive integer", value)
 
-  defp validate_option(:client_id_prefix, value) when not is_atom(value),
-    do: validation_error(:client_id_prefix, "an atom", value)
+  defp validate_option(:client_id_prefix, value) when not is_binary(value),
+    do: validation_error(:client_id_prefix, "a string", value)
 
   defp validate_option(:sasl, value) do
     with {mechanism, username, password}

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -25,7 +25,7 @@ defmodule BroadwayKafka.BrodClient do
     :ssl,
     :sasl,
     :connect_timeout,
-    :client_id
+    :client_id_prefix
   ]
 
   @default_receive_interval 2000
@@ -239,8 +239,8 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:max_wait_time, value) when not is_integer(value) or value < 1,
     do: validation_error(:max_wait_time, "a positive integer", value)
 
-  defp validate_option(:client_id, value) when not is_atom(value),
-    do: validation_error(:client_id, "an atom", value)
+  defp validate_option(:client_id_prefix, value) when not is_atom(value),
+    do: validation_error(:client_id_prefix, "an atom", value)
 
   defp validate_option(:sasl, value) do
     with {mechanism, username, password}
@@ -295,7 +295,7 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_client_config(opts) do
     with {:ok, [_ | _] = config} <-
            validate_supported_opts(opts, :client_config, @supported_client_config_options),
-         {:ok, _} <- validate(config, :client_id),
+         {:ok, _} <- validate(config, :client_id_prefix),
          {:ok, _} <- validate(config, :sasl),
          {:ok, _} <- validate(config, :ssl),
          {:ok, _} <- validate(config, :connect_timeout) do

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -24,7 +24,8 @@ defmodule BroadwayKafka.BrodClient do
   @supported_client_config_options [
     :ssl,
     :sasl,
-    :connect_timeout
+    :connect_timeout,
+    :client_id
   ]
 
   @default_receive_interval 2000
@@ -238,6 +239,9 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:max_wait_time, value) when not is_integer(value) or value < 1,
     do: validation_error(:max_wait_time, "a positive integer", value)
 
+  defp validate_option(:client_id, value) when not is_atom(value),
+    do: validation_error(:client_id, "an atom", value)
+
   defp validate_option(:sasl, value) do
     with {mechanism, username, password}
          when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
@@ -291,6 +295,7 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_client_config(opts) do
     with {:ok, [_ | _] = config} <-
            validate_supported_opts(opts, :client_config, @supported_client_config_options),
+         {:ok, _} <- validate(config, :client_id),
          {:ok, _} <- validate(config, :sasl),
          {:ok, _} <- validate(config, :ssl),
          {:ok, _} <- validate(config, :connect_timeout) do

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -87,25 +87,23 @@ defmodule BroadwayKafka.Producer do
 
   The available options that will be internally passed to `:brod.start_client/3`.
 
-    * `:client_id` - Optional. An atom that will be passed to `:brod` as the client id parameter for the connection. Example:
-    `client_id: :"\#{Node.self()} - \#{__MODULE__}"`. This generates the following connection log from our integration tests:
+    * `:client_id_prefix` - Optional. An atom that will be used to build the client id passed to `:brod`. The example value
+    `client_id_prefix: :"\#{Node.self()} -"` would generate the following connection log from our integration tests:
 
-          21:35:46.455 [info] :supervisor: {:local, :brod_sup}
-          :started: [
-          pid: #PID<0.308.0>,
-          id: :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Client",
+        20:41:37.717 [info]      :supervisor: {:local, :brod_sup}
+            :started: [
+          pid: #PID<0.286.0>,
+          id: :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
           mfargs: {:brod_client, :start_link,
            [
              [localhost: 9092],
-             :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Client",
-             [
-               client_id: :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Client"
-             ]
+             :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
+             [client_id_prefix: :"nonode@nohost - "]
            ]},
           restart_type: {:permanent, 10},
           shutdown: 5000,
           child_type: :worker
-          ]
+        ]
 
     * `:sasl` - Optional. A a tuple of mechanism which can be `:plain`, `:scram_sha_256` or `:scram_sha_512`, username and password. See the `:brod`'s
     [`Authentication Support`](https://github.com/klarna/brod#authentication-support) documentation
@@ -195,8 +193,8 @@ defmodule BroadwayKafka.Producer do
       {:ok, config} ->
         {_, producer_name} = Process.info(self(), :registered_name)
 
-        client_id =
-          get_in(config, [:client_config, :client_id]) || Module.concat([producer_name, Client])
+        prefix = get_in(config, [:client_config, :client_id_prefix])
+        client_id = :"#{prefix}#{Module.concat([producer_name, Client])}"
 
         state = %{
           client: client,

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -91,20 +91,20 @@ defmodule BroadwayKafka.Producer do
     value `client_id_prefix: :"\#{Node.self()} -"` would generate the following connection log from our integration
     tests:
 
-        20:41:37.717 [info]      :supervisor: {:local, :brod_sup}
-            :started: [
-          pid: #PID<0.286.0>,
-          id: :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
-          mfargs: {:brod_client, :start_link,
-           [
-             [localhost: 9092],
-             :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
-             [client_id_prefix: :"nonode@nohost - "]
-           ]},
-          restart_type: {:permanent, 10},
-          shutdown: 5000,
-          child_type: :worker
-        ]
+          20:41:37.717 [info]      :supervisor: {:local, :brod_sup}
+          :started: [
+            pid: #PID<0.286.0>,
+            id: :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
+            mfargs: {:brod_client, :start_link,
+             [
+               [localhost: 9092],
+               :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
+               [client_id_prefix: :"nonode@nohost - "]
+             ]},
+            restart_type: {:permanent, 10},
+            shutdown: 5000,
+            child_type: :worker
+          ]
 
     * `:sasl` - Optional. A a tuple of mechanism which can be `:plain`, `:scram_sha_256` or `:scram_sha_512`, username and password. See the `:brod`'s
     [`Authentication Support`](https://github.com/klarna/brod#authentication-support) documentation

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -87,8 +87,9 @@ defmodule BroadwayKafka.Producer do
 
   The available options that will be internally passed to `:brod.start_client/3`.
 
-    * `:client_id_prefix` - Optional. An atom that will be used to build the client id passed to `:brod`. The example value
-    `client_id_prefix: :"\#{Node.self()} -"` would generate the following connection log from our integration tests:
+    * `:client_id_prefix` - Optional. A string that will be used to build the client id passed to `:brod`. The example
+    value `client_id_prefix: :"\#{Node.self()} -"` would generate the following connection log from our integration
+    tests:
 
         20:41:37.717 [info]      :supervisor: {:local, :brod_sup}
             :started: [

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -198,17 +198,17 @@ defmodule BroadwayKafka.BrodClientTest do
     end
 
     test ":client_id_prefix is an optional atom value" do
-      opts = put_in(@opts, [:client_config, :client_id_prefix], "wrong type")
+      opts = put_in(@opts, [:client_config, :client_id_prefix], :wrong_type)
 
       assert BrodClient.init(opts) ==
-               {:error, "expected :client_id_prefix to be an atom, got: \"wrong type\""}
+               {:error, "expected :client_id_prefix to be a string, got: :wrong_type"}
 
-      opts = put_in(@opts, [:client_config, :client_id_prefix], :an_atom)
+      opts = put_in(@opts, [:client_config, :client_id_prefix], "a string")
 
       assert {:ok,
               %{
                 client_config: [
-                  client_id_prefix: :an_atom
+                  client_id_prefix: "a string"
                 ]
               }} = BrodClient.init(opts)
     end

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -197,18 +197,18 @@ defmodule BroadwayKafka.BrodClientTest do
       assert fetch_config[:max_wait_time] == 3
     end
 
-    test ":client_id is an optional atom value" do
-      opts = put_in(@opts, [:client_config, :client_id], "wrong type")
+    test ":client_id_prefix is an optional atom value" do
+      opts = put_in(@opts, [:client_config, :client_id_prefix], "wrong type")
 
       assert BrodClient.init(opts) ==
-               {:error, "expected :client_id to be an atom, got: \"wrong type\""}
+               {:error, "expected :client_id_prefix to be an atom, got: \"wrong type\""}
 
-      opts = put_in(@opts, [:client_config, :client_id], :an_atom)
+      opts = put_in(@opts, [:client_config, :client_id_prefix], :an_atom)
 
       assert {:ok,
               %{
                 client_config: [
-                  client_id: :an_atom
+                  client_id_prefix: :an_atom
                 ]
               }} = BrodClient.init(opts)
     end

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -197,6 +197,22 @@ defmodule BroadwayKafka.BrodClientTest do
       assert fetch_config[:max_wait_time] == 3
     end
 
+    test ":client_id is an optional atom value" do
+      opts = put_in(@opts, [:client_config, :client_id], "wrong type")
+
+      assert BrodClient.init(opts) ==
+               {:error, "expected :client_id to be an atom, got: \"wrong type\""}
+
+      opts = put_in(@opts, [:client_config, :client_id], :an_atom)
+
+      assert {:ok,
+              %{
+                client_config: [
+                  client_id: :an_atom
+                ]
+              }} = BrodClient.init(opts)
+    end
+
     test ":sasl is an optional tuple of SASL mechanism, username and password" do
       opts = put_in(@opts, [:client_config, :sasl], :an_atom)
 

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -65,9 +65,6 @@ defmodule BroadwayKafka.ConsumerTest do
                ],
                fetch_config: [
                  max_bytes: 10_240
-               ],
-               client_config: [
-                 client_id: :"#{Node.self()} - #{Module.concat([__MODULE__, Client])}"
                ]
              ]},
           concurrency: 3

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -65,6 +65,9 @@ defmodule BroadwayKafka.ConsumerTest do
                ],
                fetch_config: [
                  max_bytes: 10_240
+               ],
+               client_config: [
+                 client_id: :"#{Node.self()} - #{Module.concat([__MODULE__, Client])}"
                ]
              ]},
           concurrency: 3


### PR DESCRIPTION
This adds a new option to the producer that is passed to the `:brod`
client connection. This makes possible to identify consumer
connections more specifically.