### PR TITLE
feat: allow sasl value to be `:undefined`

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -242,6 +242,9 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:client_id_prefix, value) when not is_binary(value),
     do: validation_error(:client_id_prefix, "a string", value)
 
+  defp validate_option(:sasl, :undefined),
+    do: {:ok, :undefined}
+
   defp validate_option(:sasl, value) do
     with {mechanism, username, password}
          when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and


### PR DESCRIPTION
Hi, thanks for this library! We've been using it in production for a year, and it just works fine.

One small issue is that if the Kafka instance doesn't require any authentication, and when we pass `:undefined` to the client's `sasl` configuration, it will lead to the following error:

```sh
   ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:shutdown, {:failed_to_start_child, #Reference<0.1878870926.3938975746.156952>, {:shutdown, {:failed_to_start_child, MyApp.ReservationWatcher.Broadway.Producer_0, {%ArgumentError{message: "invalid options given to BroadwayKafka.BrodClient.init/1, expected :sasl to be a tuple of SASL mechanism, username and password, got: :undefined"}, [{BroadwayKafka.Producer, :init, 1, [file: 'lib/broadway_kafka/producer.ex', line: 170]}, {Broadway.Topology.ProducerStage, :init, 1, [file: 'lib/broadway/topology/producer_stage.ex', line: 69]}, {GenStage, :init, 1, [file: 'lib/gen_stage.ex', line: 1722]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 423]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 390]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}}}}}}
            (broadway 0.6.2) lib/broadway/topology.ex:37: Broadway.Topology.init/1
            (stdlib 3.15) gen_server.erl:423: :gen_server.init_it/2
            (stdlib 3.15) gen_server.erl:390: :gen_server.init_it/6
            (stdlib 3.15) proc_lib.erl:226: :proc_lib.init_p_do_apply/3 
```

Indeed, `:undefined` [is a valid `sasl` option](https://github.com/kafka4beam/brod/blob/735c1edc622c10d2d776a36ec4febab1a05ee46b/include/brod_int.hrl#L45-L50) of `:brod`.

I think this will ease some configuration work if the mechanism differs in development and production. :clinking_glasses: 