### PR TITLE
Fix brod disconnection on terminate

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -110,18 +110,14 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   @impl true
-  def stop_group_coordinator(nil) do
+  def disconnect(nil, client_id) do
+    :ok = :brod.stop_client(client_id)
     :ok
   end
 
-  def stop_group_coordinator(group_coordinator) do
-    ref = Process.monitor(group_coordinator)
-    Process.exit(group_coordinator, :kill)
-
-    receive do
-      {:DOWN, ^ref, _, _, _} -> :ok
-    end
-
+  def disconnect(group_coordinator, client_id) do
+    :ok = :brod_group_coordinator.stop(group_coordinator)
+    :ok = :brod.stop_client(client_id)
     :ok
   end
 

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -126,36 +126,7 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   @impl true
-  def disconnect(nil, client_id) do
-    :ok = :brod.stop_client(client_id)
-    :ok
-  end
-
-  def disconnect(group_coordinator, client_id) do
-    ref = Process.monitor(group_coordinator)
-    Process.exit(group_coordinator, :kill)
-
-    receive do
-      {:DOWN, ^ref, _, _, _} -> :ok
-    end
-    :ok = :brod.stop_client(client_id)
-    :ok
-  end
-
-
-  @impl true
-  def disconnect(nil, client_id) do
-    :ok = :brod.stop_client(client_id)
-    :ok
-  end
-
-  def disconnect(group_coordinator, client_id) do
-    ref = Process.monitor(group_coordinator)
-    Process.exit(group_coordinator, :kill)
-
-    receive do
-      {:DOWN, ^ref, _, _, _} -> :ok
-    end
+  def disconnect(client_id) do
     :ok = :brod.stop_client(client_id)
     :ok
   end

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -116,7 +116,12 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   def disconnect(group_coordinator, client_id) do
-    :ok = :brod_group_coordinator.stop(group_coordinator)
+    ref = Process.monitor(group_coordinator)
+    Process.exit(group_coordinator, :kill)
+
+    receive do
+      {:DOWN, ^ref, _, _, _} -> :ok
+    end
     :ok = :brod.stop_client(client_id)
     :ok
   end

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -110,6 +110,40 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   @impl true
+  def stop_group_coordinator(nil) do
+    :ok
+  end
+
+  def stop_group_coordinator(group_coordinator) do
+    ref = Process.monitor(group_coordinator)
+    Process.exit(group_coordinator, :kill)
+
+    receive do
+      {:DOWN, ^ref, _, _, _} -> :ok
+    end
+
+    :ok
+  end
+
+  @impl true
+  def disconnect(nil, client_id) do
+    :ok = :brod.stop_client(client_id)
+    :ok
+  end
+
+  def disconnect(group_coordinator, client_id) do
+    ref = Process.monitor(group_coordinator)
+    Process.exit(group_coordinator, :kill)
+
+    receive do
+      {:DOWN, ^ref, _, _, _} -> :ok
+    end
+    :ok = :brod.stop_client(client_id)
+    :ok
+  end
+
+
+  @impl true
   def disconnect(nil, client_id) do
     :ok = :brod.stop_client(client_id)
     :ok

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -51,5 +51,6 @@ defmodule BroadwayKafka.KafkaClient do
 
   @callback update_topics(:brod.group_coordinator(), [:brod.topic()]) :: :ok
   @callback connected?(:brod.client()) :: boolean
+  @callback stop_group_coordinator(pid) :: :ok
   @callback disconnect(pid, :brod.client()) :: :ok
 end

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -51,5 +51,5 @@ defmodule BroadwayKafka.KafkaClient do
 
   @callback update_topics(:brod.group_coordinator(), [:brod.topic()]) :: :ok
   @callback connected?(:brod.client()) :: boolean
-  @callback stop_group_coordinator(pid) :: :ok
+  @callback disconnect(pid, :brod.client()) :: :ok
 end

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -52,5 +52,5 @@ defmodule BroadwayKafka.KafkaClient do
   @callback update_topics(:brod.group_coordinator(), [:brod.topic()]) :: :ok
   @callback connected?(:brod.client()) :: boolean
   @callback stop_group_coordinator(pid) :: :ok
-  @callback disconnect(pid, :brod.client()) :: :ok
+  @callback disconnect(:brod.client()) :: :ok
 end

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -373,6 +373,10 @@ defmodule BroadwayKafka.Producer do
     {:noreply, [], %{state | group_coordinator: nil}}
   end
 
+  def handle_info({:EXIT, _sup_pid, reason}, state) do
+    {:stop, reason, state}
+  end
+
   @impl GenStage
   def handle_info(:reconnect, state) do
     if state.client.connected?(state.client_id) do

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -456,7 +456,8 @@ defmodule BroadwayKafka.Producer do
   @impl GenStage
   def terminate(_reason, state) do
     %{client: client, group_coordinator: group_coordinator, client_id: client_id} = state
-    client.disconnect(group_coordinator, client_id)
+    client.stop_group_coordinator(group_coordinator)
+    client.disconnect(client_id)
     :ok
   end
 

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -185,6 +185,8 @@ defmodule BroadwayKafka.Producer do
 
   @impl GenStage
   def init(opts) do
+    Process.flag(:trap_exit, true)
+
     client = opts[:client] || BroadwayKafka.BrodClient
 
     case client.init(opts) do
@@ -449,7 +451,8 @@ defmodule BroadwayKafka.Producer do
 
   @impl GenStage
   def terminate(_reason, state) do
-    state.client.stop_group_coordinator(state.group_coordinator)
+    %{client: client, group_coordinator: group_coordinator, client_id: client_id} = state
+    client.disconnect(group_coordinator, client_id)
     :ok
   end
 

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -102,6 +102,11 @@ defmodule BroadwayKafka.ProducerTest do
     end
 
     @impl true
+    def stop_group_coordinator(_pid) do
+      :ok
+    end
+
+    @impl true
     def disconnect(_pid, _client_id) do
       :ok
     end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -102,7 +102,7 @@ defmodule BroadwayKafka.ProducerTest do
     end
 
     @impl true
-    def stop_group_coordinator(_pid) do
+    def disconnect(_pid, _client_id) do
       :ok
     end
 


### PR DESCRIPTION
This PR fixes an issue that leaves brod processes running after the pipeline is stopped. 
Killing the group_coordinator is not enough to terminate all brod processes related to the pipeline, so a stop_client is added.
Built in brod functions are used for disconnection, it can be changed to killing the processes.