### PR TITLE
Add heartbeat_rate_seconds option to group_config

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -12,7 +12,8 @@ defmodule BroadwayKafka.BrodClient do
   @supported_group_config_options [
     :offset_commit_interval_seconds,
     :rejoin_delay_seconds,
-    :session_timeout_seconds
+    :session_timeout_seconds,
+    :heartbeat_rate_seconds
   ]
 
   @supported_fetch_config_options [
@@ -251,6 +252,9 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:session_timeout_seconds, value) when not is_integer(value) or value < 1,
     do: validation_error(:session_timeout_seconds, "a positive integer", value)
 
+  defp validate_option(:heartbeat_rate_seconds, value) when not is_integer(value) or value < 1,
+    do: validation_error(:heartbeat_rate_seconds, "a positive integer", value)
+
   defp validate_option(:min_bytes, value) when not is_integer(value) or value < 1,
     do: validation_error(:min_bytes, "a positive integer", value)
 
@@ -301,7 +305,8 @@ defmodule BroadwayKafka.BrodClient do
            validate_supported_opts(opts, :group_config, @supported_group_config_options),
          {:ok, _} <- validate(config, :offset_commit_interval_seconds),
          {:ok, _} <- validate(config, :rejoin_delay_seconds),
-         {:ok, _} <- validate(config, :session_timeout_seconds) do
+         {:ok, _} <- validate(config, :session_timeout_seconds),
+         {:ok, _} <- validate(config, :heartbeat_rate_seconds) do
       {:ok, config}
     end
   end

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -70,7 +70,7 @@ defmodule BroadwayKafka.Producer do
     * `:heartbeat_rate_seconds` - Optional. Time in seconds for member to 'ping' group coordinator.
       Heartbeats are used to ensure that the consumer's session stays active and
       to facilitate rebalancing when new consumers join or leave the group.
-      The value must be set lower than :session_timeout_seconds, but typically should be set no higher than 1/3 of that value.
+      The value must be set lower than `:session_timeout_seconds`, typically equal to or lower than 1/3 of that value.
       It can be adjusted even lower to control the expected time for normal rebalances. Default is 5 seconds.
 
   ## Fetch config options

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -65,7 +65,7 @@ defmodule BroadwayKafka.Producer do
     * `:session_timeout_seconds` - Optional. Time in seconds the group coordinator broker waits
       before considering a member 'down' if no heartbeat or any kind of request is received.
       A group member may also consider the coordinator broker 'down' if no heartbeat response
-      is received in the past N seconds. Default is 10 seconds.
+      is received in the past N seconds. Default is 30 seconds.
 
     * `:heartbeat_rate_seconds` - Optional. Time in seconds for member to 'ping' group coordinator.
       Heartbeats are used to ensure that the consumer's session stays active and

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -67,6 +67,12 @@ defmodule BroadwayKafka.Producer do
       A group member may also consider the coordinator broker 'down' if no heartbeat response
       is received in the past N seconds. Default is 10 seconds.
 
+    * `:heartbeat_rate_seconds` - Optional. Time in seconds for member to 'ping' group coordinator.
+      Heartbeats are used to ensure that the consumer's session stays active and
+      to facilitate rebalancing when new consumers join or leave the group.
+      The value must be set lower than :session_timeout_seconds, but typically should be set no higher than 1/3 of that value.
+      It can be adjusted even lower to control the expected time for normal rebalances. Default is 5 seconds.
+
   ## Fetch config options
 
   The available options that will be internally passed to `:brod.fetch/5`.

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -161,6 +161,18 @@ defmodule BroadwayKafka.BrodClientTest do
       assert group_config[:session_timeout_seconds] == 3
     end
 
+    test ":heartbeat_rate_seconds is an optional positive integer" do
+      opts = put_in(@opts, [:group_config, :heartbeat_rate_seconds], :an_atom)
+
+      assert BrodClient.init(opts) ==
+               {:error,
+                "expected :heartbeat_rate_seconds to be a positive integer, got: :an_atom"}
+
+      opts = put_in(@opts, [:group_config, :heartbeat_rate_seconds], 3)
+      {:ok, %{group_config: group_config}} = BrodClient.init(opts)
+      assert group_config[:heartbeat_rate_seconds] == 3
+    end
+
     test ":min_bytes is an optional positive integer" do
       opts = put_in(@opts, [:fetch_config, :min_bytes], :an_atom)
 


### PR DESCRIPTION
This adds `heartbeat_rate_seconds` option to group_config of producer. With this option, it will be possible to set heartbeat rate in seconds  (default was 5 seconds)