### PR TITLE
Fix integration tests

### DIFF
--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -116,7 +116,7 @@ defmodule BroadwayKafka.ConsumerTest do
     {broadway_pid, messages_agent} = start_broadway()
 
     # Let's wait for the assignments before start sending messages
-    wait_for_assignments(broadway_pid)
+    wait_for_assignments(MyBroadway)
 
     IO.puts("Sending messages...")
     send_messages(Config.n_messages(), hosts, topic)
@@ -251,9 +251,9 @@ defmodule BroadwayKafka.ConsumerTest do
     Enum.reverse(ordering_problems)
   end
 
-  defp wait_for_assignments(broadway_pid) do
+  defp wait_for_assignments(broadway_name) do
     producers =
-      broadway_pid
+      broadway_name
       |> Broadway.producer_names()
       |> Enum.map(fn producer ->
         pid = Process.whereis(producer)

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -107,7 +107,7 @@ defmodule BroadwayKafka.ProducerTest do
     end
 
     @impl true
-    def disconnect(_pid, _client_id) do
+    def disconnect(_client_id) do
       :ok
     end
 


### PR DESCRIPTION
Integration tests were failing and these changes are needed to solve part of the problem.

- Function `Broadway.producer_names()` expects a Module name instead of a PID
- Behaviour BroadwayKafka.KafkaClient specifies the callback `disconnect/1`, not `disconnect/2`

I believe this change to the [Broadway](https://github.com/dashbitco/broadway) lib is also needed for the tests to work properly:
https://github.com/dashbitco/broadway/pull/287