### PR TITLE
fix(docs): keyword list example is invalid elixir

### DIFF
--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -14,7 +14,7 @@ defmodule BroadwayKafka.Producer do
       e.g. [localhost: 9092]. Examples:
 
           # Keyword
-          [kafka-vm1: 9092, kafka-vm2: 9092, kafka-vm3: 9092]
+          ["kafka-vm1": 9092, "kafka-vm2": 9092, "kafka-vm3": 9092]
 
           # List of tuples
           [{"kafka-vm1", 9092}, {"kafka-vm2", 9092}, {"kafka-vm3", 9092}]


### PR DESCRIPTION
Just realized that `[kafka-vm1: 9092, ...]` is not valid elixir so I'm just going with `["kafka-vm1": 9092, ...]` another option would be to have something like `kafkavm1: 9092`.