### PR TITLE
Support for custom brod sasl authenticators 

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -265,6 +265,9 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:sasl, :undefined),
     do: {:ok, :undefined}
 
+  defp validate_option(:sasl, value = {:callback, _callback_module, _opts}),
+    do: {:ok, value}
+
   defp validate_option(:sasl, value) do
     with {mechanism, username, password}
          when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -248,6 +248,17 @@ defmodule BroadwayKafka.BrodClientTest do
               }} = BrodClient.init(opts)
     end
 
+    test ":sasl is an optional tuple of :callback, SASL Authentication Plugin module and opts" do
+      opts = put_in(@opts, [:client_config, :sasl], {:callback, FakeSaslMechanismPlugin, {}})
+
+      assert {:ok,
+              %{
+                client_config: [
+                  sasl: {:callback, FakeSaslMechanismPlugin, {}}
+                ]
+              }} = BrodClient.init(opts)
+    end
+
     test ":ssl is an optional boolean or keyword list" do
       opts = put_in(@opts, [:client_config, :ssl], :an_atom)
 
@@ -291,6 +302,15 @@ defmodule BroadwayKafka.BrodClientTest do
                   connect_timeout: 5000
                 ]
               }} = BrodClient.init(opts)
+    end
+  end
+
+  defmodule FakeSaslMechanismPlugin do
+    @behaviour :kpro_auth_backend
+
+    @impl true
+    def auth(_host, _sock, _mod, _client_id, _timeout, _sasl_opts = {}) do
+      :ok
     end
   end
 end


### PR DESCRIPTION
Closes #82 

Validation added for :callback modules to be passed as part of SASL config. This is to enable support for custom auth plugins to be invoked that is already available with :brod library
https://github.com/kafka4beam/brod#authentication-support