### PR TITLE
Improvement in integration test

### DIFF
--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -172,23 +172,21 @@ defmodule BroadwayKafka.ConsumerTest do
   end
 
   defp reset_topic(topic) do
-    cmd_opts = [into: IO.stream(:stdio, :line), stderr_to_stdout: true]
-    delete_args = ["--delete", "--zookeeper", "localhost:2181", "--topic", topic]
+    brokers = [{"localhost", 9092}]
 
-    create_args = [
-      "--create",
-      "--zookeeper",
-      "localhost:2181",
-      "--replication-factor",
-      "1",
-      "--partitions",
-      "3",
-      "--topic",
-      topic
+    :brod.delete_topics(brokers, [topic], 1_000)
+
+    topic_config = [
+      %{
+        config_entries: [],
+        num_partitions: 3,
+        replica_assignment: [],
+        replication_factor: 1,
+        topic: topic
+      }
     ]
 
-    System.cmd("kafka-topics", delete_args, cmd_opts)
-    System.cmd("kafka-topics", create_args, cmd_opts)
+    :brod.create_topics(brokers, topic_config, %{timeout: 1_000})
   end
 
   defp send_messages(n_messages, hosts, topic) do

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -14,17 +14,33 @@ defmodule BroadwayKafka.ConsumerTest do
 
   # Setup
 
-  1. Install Kafka locally on port 9092 (default)
+  1. Create docker-compose.yml file
 
-  See https://kafka.apache.org/quickstart for instructions
+  ```
+  version: '3.9'
+  services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "127.0.0.1:2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.13-2.7.1
+    ports:
+      - "127.0.0.1:9092:9092"
+    environment:
+      KAFKA_LISTENERS: "INTERNAL://:29092,EXTERNAL://:9092"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:29092,EXTERNAL://localhost:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zookeeper
+  ```
 
-  2. Start Zookeeper
-
-      $ zookeeper-server-start.sh config/zookeeper.properties
-
-  3. Start Kafka
-
-      $ kafka-server-start.sh config/server.properties
+  1. Run Docker
+     $ docker compose up -d
 
   # Running only integration tests
 


### PR DESCRIPTION
I was trying to run the integration tests but noticed it expects the Kafka helper scripts to be installed locally.

1. I've changed that to use brod directly to delete and create topics
2. I also updated the instruction to setup a docker-compose file with Kafka as oppose to installing Kafka locally.