### PR TITLE
Allow blocking the queue and retrying messages from the failed message's offset

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -41,6 +41,8 @@ defmodule BroadwayKafka.BrodClient do
 
   @default_offset_reset_policy :latest
 
+  @default_retry_on_failure false
+
   @impl true
   def init(opts) do
     with {:ok, hosts} <- validate(opts, :hosts, required: true),
@@ -54,6 +56,8 @@ defmodule BroadwayKafka.BrodClient do
            validate(opts, :offset_commit_on_ack, default: @default_offset_commit_on_ack),
          {:ok, offset_reset_policy} <-
            validate(opts, :offset_reset_policy, default: @default_offset_reset_policy),
+         {:ok, retry_on_failure} <-
+           validate(opts, :retry_on_failure, default: @default_retry_on_failure),
          {:ok, group_config} <- validate_group_config(opts),
          {:ok, fetch_config} <- validate_fetch_config(opts),
          {:ok, client_config} <- validate_client_config(opts) do
@@ -66,6 +70,7 @@ defmodule BroadwayKafka.BrodClient do
          reconnect_timeout: reconnect_timeout,
          offset_commit_on_ack: offset_commit_on_ack,
          offset_reset_policy: offset_reset_policy,
+         retry_on_failure: retry_on_failure,
          group_config: [{:offset_commit_policy, @offset_commit_policy} | group_config],
          fetch_config: Map.new(fetch_config || []),
          client_config: client_config
@@ -228,6 +233,9 @@ defmodule BroadwayKafka.BrodClient do
 
   defp validate_option(:offset_commit_on_ack, value) when not is_boolean(value),
     do: validation_error(:offset_commit_on_ack, "a boolean", value)
+
+  defp validate_option(:retry_on_failure, value) when not is_boolean(value),
+    do: validation_error(:retry_on_failure, "a boolean", value)
 
   defp validate_option(:offset_reset_policy, value)
        when value not in @offset_reset_policy_values do

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -7,6 +7,7 @@ defmodule BroadwayKafka.KafkaClient do
            group_id: :brod.group_id(),
            reconnect_timeout: non_neg_integer,
            offset_commit_on_ack: boolean,
+           retry_on_failure: boolean,
            topics: [:brod.topic()],
            group_config: keyword,
            client_config: keyword

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -409,8 +409,10 @@ defmodule BroadwayKafka.Producer do
   end
 
   @impl GenStage
+  def handle_info({:ack, key, offsets, []}, state), do: handle_info({:ack, key, offsets}, state)
+
   def handle_info({:ack, key, offsets, failed_offsets}, state) do
-    %{group_coordinator: _group_coordinator, client: _client, acks: acks, config: config} = state
+    %{acks: acks, config: config} = state
 
     if config.retry_on_failure do
       %{^key => {_pending, last_offset, seen}} = acks


### PR DESCRIPTION
Hi there 👋🏻 ! I'd like to implement the option to block the queue and retry failed messages from the failed message's offset. It's the same need as in https://github.com/dashbitco/broadway_kafka/issues/30.

Blocking the queue and retrying failed has the advantage that bugs can be detected early and can be fixed on the consumer (and possibly the producer's) side, without losing the order of messages. It has the disadvantage that non-failing messages will be processed many times over. And it can only work with a single `BroadwayKafka.Producer` per partition. But that's a penalty that I'm willing to take to keep a consistent messages order.

The flow:
1. BroadwayKafka consumes messages as usual.
2. One (or more) messages fail to be processed.
3. The failed messages are marked as `failed`.
4. The BroadwayKafka producer retries messages from the earliest failed offset.

It will only work if the Producer commits offsets after the queue in its state has been drained.

This PR implements this flow, and on my local environment I can confirm that the failed message is continuously retried. I added a configuration option called `retry_on_failure` with the default set to `false`.

Unfortunately, I'm struggling with the test a bit. It looks like the current implementation of `MessageServer` can't retry messages and only pushes (but maybe I'm mistaken). Ideally, the messages in the queue are retried until the whole queue is empty, and after 2 confirmed retries we stop the process and the test passes.

Is it possible to add retry logic to `ProducerTest` without rewriting `MessageServer`? Feedback is very welcome 🙏🏻 

Thanks for writing such great libraries! 🙇🏻 