### PR TITLE
Use Ring style as buffer

### DIFF
--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -673,7 +673,7 @@ defmodule BroadwayKafka.Producer do
             {acks, demand, Enum.reverse(acc), queue}
 
           {0, _} ->
-            {acks, demand, Enum.reverse(acc), :queue.in_r({key, rest}, queue)}
+            {acks, demand, Enum.reverse(acc), :queue.in({key, rest}, queue)}
 
           {_, []} ->
             dequeue_many(queue, acks, demand, acc)


### PR DESCRIPTION
This my 5th attempts to address #98.

This also supersedes #102.

As [Jose suggested](https://github.com/dashbitco/broadway_kafka/pull/102#issuecomment-1153626353) I started to implementing BroadwayKafka.Buffer behaviour and while implementing Queue and Ring, I noticed that both implementing are identical except the patch that in this PR is submitted. 


This way we are basically implementing a ring buffer. After the data for a specific partition is read, we put it to end of queue. This allows fairer consumption of cross partitions.

Before this patch, we always read from a single partitions and then move
on the next partitions after that partition was fully consumed. However since we are using
GenStage.PartitionDispatcher(using partition as partition key), the messages would get stuck into the dispatcher pending for a single consumer to consume the data.


This patch doesn't fix the overloading `GenStage.PartitionDispatcher` part. Still we are overloading  `GenStage.PartitionDispatcher` with load of data and when the time comes to do rebalancing, `GenStage.PartitionDispatcher` is still busy giving out old messages to the consumers.


~⚠️ I have not had a chance to test it in prod yet.~