### PR TITLE
send telemetry when assignments_revoked is executed

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule BroadwayKafka.MixProject do
     [
       {:broadway, "~> 1.0"},
       {:brod, "~> 3.16"},
+      {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:ex_doc, ">= 0.19.0", only: :docs}
     ]
   end


### PR DESCRIPTION
This is a much better solution than #96 to give inside about rebalancing occurrence and the time it takes to be finished.

This allows to track down issues with end-less rebalancing, if the time it takes is more than the :rebalance_timeout_seconds then it means you have a problem with consuming the events on time.