### PR TITLE
disable offset_commit_on_ack  during revoke assignment call

### DIFF
--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -399,7 +399,14 @@ defmodule BroadwayKafka.Producer do
 
     if new_offset do
       try do
-        client.ack(group_coordinator, generation_id, topic, partition, new_offset, config)
+        client.ack(
+          group_coordinator,
+          generation_id,
+          topic,
+          partition,
+          new_offset,
+          disable_offset_commit_during_revoke_call(config, state.revoke_caller)
+        )
       catch
         kind, reason ->
           Logger.error(Exception.format(kind, reason, __STACKTRACE__))
@@ -738,5 +745,9 @@ defmodule BroadwayKafka.Producer do
 
   defp is_draining_after_revoke?(table_name) do
     :ets.lookup_element(table_name, :draining, 2)
+  end
+
+  defp disable_offset_commit_during_revoke_call(config, revoke_caller) do
+    %{config | offset_commit_on_ack: !revoke_caller && config.offset_commit_on_ack}
   end
 end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -634,6 +634,7 @@ defmodule BroadwayKafka.ProducerTest do
                receive_interval: 0,
                reconnect_timeout: 10,
                max_bytes: 10,
+               offset_commit_on_ack: false,
                ack_raises_on_offset: ack_raises_on_offset
              ]},
           concurrency: producers_concurrency


### PR DESCRIPTION
brod_group_coordinator makes a sync call to BroadwayKafka and it's not able to reply on sync call via :brod_group_coordinator.commit_offsets from BroadwayKafka. Without this fix BroadwayKafka calls are timed out and causes endless rebalancing because BroadwayKafka is not able to release BroadwayKafka.assignments_revoked call in expected time

This fixes #118 & #92