### PR TITLE
fix integration tests

### DIFF
--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -169,11 +169,11 @@ defmodule BroadwayKafka.ConsumerTest do
 
     topic_config = [
       %{
-        config_entries: [],
         num_partitions: 3,
-        replica_assignment: [],
         replication_factor: 1,
-        topic: topic
+        name: topic,
+        assignments: [],
+        configs: []
       }
     ]
 


### PR DESCRIPTION
For some reasons the arguments to create a topic during integration have changed. Not sure what dependency update caused it but it right now only works with this arguments.