### PR TITLE
fix: check draining state from ets

### DIFF
--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -748,10 +748,10 @@ defmodule BroadwayKafka.Producer do
   end
 
   defp disable_offset_commit_during_revoke_call(config, state) do
-    draining? =
-      state.revoke_caller != nil or is_draining_after_revoke?(state.draining_after_revoke_flag)
+    offset_commit_on_ack =
+      not is_draining_after_revoke?(state.draining_after_revoke_flag) and
+        state.config.offset_commit_on_ack
 
-    offset_commit_on_ack = not draining? and state.config.offset_commit_on_ack
     %{config | offset_commit_on_ack: offset_commit_on_ack}
   end
 end

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -405,7 +405,7 @@ defmodule BroadwayKafka.Producer do
           topic,
           partition,
           new_offset,
-          disable_offset_commit_during_revoke_call(config, state.revoke_caller)
+          disable_offset_commit_during_revoke_call(config, state)
         )
       catch
         kind, reason ->
@@ -747,7 +747,11 @@ defmodule BroadwayKafka.Producer do
     :ets.lookup_element(table_name, :draining, 2)
   end
 
-  defp disable_offset_commit_during_revoke_call(config, revoke_caller) do
-    %{config | offset_commit_on_ack: !revoke_caller && config.offset_commit_on_ack}
+  defp disable_offset_commit_during_revoke_call(config, state) do
+    draining? =
+      state.revoke_caller != nil or is_draining_after_revoke?(state.draining_after_revoke_flag)
+
+    offset_commit_on_ack = not draining? and state.config.offset_commit_on_ack
+    %{config | offset_commit_on_ack: offset_commit_on_ack}
   end
 end


### PR DESCRIPTION
This pull implements a fix for pull https://github.com/dashbitco/broadway_kafka/pull/121

To check if we're in draining state or not, we should check both from state and from ets table

This fixes https://github.com/dashbitco/broadway_kafka/issues/118