### PR TITLE
run integration test on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
       - master
 
 jobs:
+  integration-test:
+    name: integration test
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        elixirbase:
+          - "1.11.3-erlang-23.2.5-alpine-3.16.0"
+          - "1.14.3-erlang-25.3-alpine-3.17.2"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.7.2/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Kafka Brodway integration-test under ${{matrix.elixirbase}}
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +integration-test
   test:
     runs-on: ubuntu-18.04
     env:

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,36 @@
+VERSION  0.7
+
+all:
+    BUILD \
+        --build-arg ELIXIR_BASE=1.11.3-erlang-23.2.5-alpine-3.16.0 \
+        --build-arg ELIXIR_BASE=1.14.3-erlang-25.3-alpine-3.17.2 \
+        +integration-test
+
+
+setup-base:
+    ARG ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0
+    FROM hexpm/elixir:$ELIXIR_BASE
+    RUN apk add --no-progress --update build-base
+    RUN mix local.rebar --force
+    RUN mix local.hex --force
+    ENV ELIXIR_ASSERT_TIMEOUT=10000
+    WORKDIR /src/broadway_kafka
+
+
+integration-test-base:
+    FROM +setup-base
+    RUN apk add --no-progress --update docker docker-compose git
+
+
+integration-test:
+    FROM +integration-test-base
+    COPY mix.exs mix.lock .formatter.exs docker-compose.yml ./
+    RUN mix deps.get
+
+    COPY --dir lib test ./
+
+    # then run the tests
+    WITH DOCKER --compose docker-compose.yml
+        RUN set -e; \
+	    mix test --only integration
+    END


### PR DESCRIPTION
With this PR, we run integration tests on CI. I've used Earthly as was purposed in #61.

This PR closes #61


Currently the [GitHub Action tests runs on Elixir `1.7.4`](https://github.com/dashbitco/broadway_kafka/blob/main/.github/workflows/ci.yml#L19) but I couldn't make the docker-compose work on [1.7.4-erlang-21.3.8.17-alpine-3.12.0](https://hub.docker.com/layers/hexpm/elixir/1.7.4-erlang-21.3.8.17-alpine-3.12.0/images/sha256-480fde4dcb426265504a2d670f9a637cdf2c11a777cb6a502ac33ea2557c7154?context=explore) therefor I've skipped running the integration tests on this older version. 

Instead I only configured to run the integration tests on Elixir `1.11.3` and `1.14.3`. currently the 