### PR TITLE
set GitHub Action runner to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Kafka Brodway integration-test under ${{matrix.elixirbase}}
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +integration-test
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: test
     strategy:


### PR DESCRIPTION
ubuntu-18.04 is [not supported](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) on GitHub Action.

~I'm not sure if it's better to point it to `ubuntu-22.04` or `ubuntu-latest`.~
Used `ubuntu-20.04` as we need Erlang/OTP 23 in CI
