### PR TITLE
feat: implement shared client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
               elixir: 1.7.4
               otp: 21.3.8.17
           - pair:
-              elixir: 1.11.3
-              otp: 23.2.5
+              elixir: 1.15.6
+              otp: 26.1.1
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -47,6 +47,8 @@ defmodule BroadwayKafka.BrodClient do
 
   @default_begin_offset :assigned
 
+  @default_shared_client false
+
   @impl true
   def init(opts) do
     with {:ok, hosts} <- validate(opts, :hosts, required: true),
@@ -62,6 +64,8 @@ defmodule BroadwayKafka.BrodClient do
            validate(opts, :offset_reset_policy, default: @default_offset_reset_policy),
          {:ok, begin_offset} <-
            validate(opts, :begin_offset, default: @default_begin_offset),
+         {:ok, shared_client} <-
+           validate(opts, :shared_client, default: @default_shared_client),
          {:ok, group_config} <- validate_group_config(opts),
          {:ok, fetch_config} <- validate_fetch_config(opts),
          {:ok, client_config} <- validate_client_config(opts) do
@@ -77,14 +81,16 @@ defmodule BroadwayKafka.BrodClient do
          begin_offset: begin_offset,
          group_config: [{:offset_commit_policy, @offset_commit_policy} | group_config],
          fetch_config: Map.new(fetch_config || []),
-         client_config: client_config
+         client_config: client_config,
+         shared_client: shared_client,
+         shared_client_id: build_shared_client_id(opts)
        }}
     end
   end
 
   @impl true
   def setup(stage_pid, client_id, callback_module, config) do
-    with :ok <- :brod.start_client(config.hosts, client_id, config.client_config),
+    with :ok <- do_start_brod_client(config.hosts, client_id, config.client_config),
          {:ok, group_coordinator} <-
            start_link_group_coordinator(stage_pid, client_id, callback_module, config) do
       Process.monitor(client_id)
@@ -147,6 +153,20 @@ defmodule BroadwayKafka.BrodClient do
     end
   end
 
+  @impl true
+  def prepare_for_start(broadway_opts) do
+    {_, producer_opts} = broadway_opts[:producer][:module]
+    init_opts = Keyword.put(producer_opts, :broadway, broadway_opts)
+
+    case init(init_opts) do
+      {:error, message} ->
+        raise ArgumentError, "invalid options given to #{__MODULE__}.init/1, " <> message
+
+      {:ok, config} ->
+        {child_specs(config), broadway_opts}
+    end
+  end
+
   defp lookup_offset(hosts, topic, partition, policy, client_config) do
     case :brod.resolve_offset(hosts, topic, partition, policy, client_config) do
       {:ok, offset} ->
@@ -172,6 +192,19 @@ defmodule BroadwayKafka.BrodClient do
       callback_module,
       stage_pid
     )
+  end
+
+  defp child_specs(%{shared_client: false} = _config), do: []
+
+  defp child_specs(%{shared_client: true} = config) do
+    [
+      %{
+        id: config.shared_client_id,
+        start:
+          {:brod, :start_link_client,
+           [config.hosts, config.shared_client_id, config.client_config]}
+      }
+    ]
   end
 
   defp validate(opts, key, options \\ []) when is_list(opts) do
@@ -267,6 +300,9 @@ defmodule BroadwayKafka.BrodClient do
 
   defp validate_option(:client_id_prefix, value) when not is_binary(value),
     do: validation_error(:client_id_prefix, "a string", value)
+
+  defp validate_option(:shared_client, value) when not is_boolean(value),
+    do: validation_error(:shared_client, "a boolean", value)
 
   defp validate_option(:sasl, :undefined),
     do: {:ok, :undefined}
@@ -387,4 +423,29 @@ defmodule BroadwayKafka.BrodClient do
   end
 
   defp parse_hosts(hosts), do: hosts
+
+  defp build_shared_client_id(opts) do
+    if opts[:shared_client] do
+      prefix = get_in(opts, [:client_config, :client_id_prefix])
+      broadway_name = opts[:broadway][:name]
+      :"#{prefix}#{Module.concat(broadway_name, SharedClient)}"
+    end
+  end
+
+  defp do_start_brod_client(hosts, client_id, client_config) do
+    case :brod.start_client(hosts, client_id, client_config) do
+      :ok ->
+        :ok
+
+      # Because  we are starting the client on the broadway supervison tree
+      # instead of the :brod supervisor, the already_started error
+      # is not properly handled by :brod.start_client/3 for shared clients
+      # So we must handle it here.
+      {:error, {{:already_started, _}, _}} ->
+        :ok
+
+      error ->
+        error
+    end
+  end
 end

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -54,9 +54,4 @@ defmodule BroadwayKafka.KafkaClient do
   @callback update_topics(:brod.group_coordinator(), [:brod.topic()]) :: :ok
   @callback connected?(:brod.client()) :: boolean
   @callback disconnect(:brod.client()) :: :ok
-
-  @callback shared_client_child_spec(config()) :: [child_spec]
-            when child_spec: :supervisor.child_spec() | {module, any} | module
-
-  @optional_callbacks shared_client_child_spec: 1
 end

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -9,7 +9,9 @@ defmodule BroadwayKafka.KafkaClient do
            offset_commit_on_ack: boolean,
            topics: [:brod.topic()],
            group_config: keyword,
-           client_config: keyword
+           client_config: keyword,
+           shared_client: boolean(),
+           shared_client_id: atom() | nil
          }
 
   @typep offset_reset_policy :: :earliest | :latest
@@ -52,4 +54,10 @@ defmodule BroadwayKafka.KafkaClient do
   @callback update_topics(:brod.group_coordinator(), [:brod.topic()]) :: :ok
   @callback connected?(:brod.client()) :: boolean
   @callback disconnect(:brod.client()) :: :ok
+
+  @callback prepare_for_start(broadway_opts :: keyword()) ::
+              {[child_spec], updated_opts :: keyword()}
+            when child_spec: :supervisor.child_spec() | {module, any} | module
+
+  @optional_callbacks prepare_for_start: 1
 end

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -55,9 +55,8 @@ defmodule BroadwayKafka.KafkaClient do
   @callback connected?(:brod.client()) :: boolean
   @callback disconnect(:brod.client()) :: :ok
 
-  @callback prepare_for_start(broadway_opts :: keyword()) ::
-              {[child_spec], updated_opts :: keyword()}
+  @callback shared_client_child_spec(config()) :: [child_spec]
             when child_spec: :supervisor.child_spec() | {module, any} | module
 
-  @optional_callbacks prepare_for_start: 1
+  @optional_callbacks shared_client_child_spec: 1
 end

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -235,54 +235,48 @@ defmodule BroadwayKafka.Producer do
   def init(opts) do
     Process.flag(:trap_exit, true)
 
-    client = opts[:client] || BroadwayKafka.BrodClient
+    config = opts[:initialized_client_config]
 
-    case opts[:initialized_client_config] || client.init(opts) do
-      {:error, message} ->
-        raise ArgumentError, "invalid options given to #{inspect(client)}.init/1, " <> message
+    draining_after_revoke_flag =
+      self()
+      |> drain_after_revoke_table_name!()
+      |> drain_after_revoke_table_init!()
 
-      {:ok, config} ->
-        {_, producer_name} = Process.info(self(), :registered_name)
+    prefix = get_in(config, [:client_config, :client_id_prefix])
 
-        draining_after_revoke_flag =
-          self()
-          |> drain_after_revoke_table_name!()
-          |> drain_after_revoke_table_init!()
+    {_, producer_name} = Process.info(self(), :registered_name)
 
-        prefix = get_in(config, [:client_config, :client_id_prefix])
+    client_id =
+      config[:shared_client_id] || :"#{prefix}#{Module.concat([producer_name, Client])}"
 
-        client_id =
-          config[:shared_client_id] || :"#{prefix}#{Module.concat([producer_name, Client])}"
+    max_demand =
+      with [{_first, processor_opts}] <- opts[:broadway][:processors],
+           max_demand when is_integer(max_demand) <- processor_opts[:max_demand] do
+        max_demand
+      else
+        _ -> 10
+      end
 
-        max_demand =
-          with [{_first, processor_opts}] <- opts[:broadway][:processors],
-               max_demand when is_integer(max_demand) <- processor_opts[:max_demand] do
-            max_demand
-          else
-            _ -> 10
-          end
+    state = %{
+      client: opts[:client] || BroadwayKafka.BrodClient,
+      client_id: client_id,
+      group_coordinator: nil,
+      receive_timer: nil,
+      receive_interval: config.receive_interval,
+      reconnect_timeout: config.reconnect_timeout,
+      acks: Acknowledger.new(),
+      config: config,
+      allocator_names: allocator_names(opts[:broadway]),
+      revoke_caller: nil,
+      draining_after_revoke_flag: draining_after_revoke_flag,
+      demand: 0,
+      shutting_down?: false,
+      buffer: :queue.new(),
+      max_demand: max_demand,
+      shared_client: config.shared_client
+    }
 
-        state = %{
-          client: client,
-          client_id: client_id,
-          group_coordinator: nil,
-          receive_timer: nil,
-          receive_interval: config.receive_interval,
-          reconnect_timeout: config.reconnect_timeout,
-          acks: Acknowledger.new(),
-          config: config,
-          allocator_names: allocator_names(opts[:broadway]),
-          revoke_caller: nil,
-          draining_after_revoke_flag: draining_after_revoke_flag,
-          demand: 0,
-          shutting_down?: false,
-          buffer: :queue.new(),
-          max_demand: max_demand,
-          shared_client: config.shared_client
-        }
-
-        {:producer, connect(state)}
-    end
+    {:producer, connect(state)}
   end
 
   defp allocator_names(broadway_config) do
@@ -518,27 +512,21 @@ defmodule BroadwayKafka.Producer do
 
     {producer_mod, producer_opts} = opts[:producer][:module]
 
-    {extra_child_specs, initialized_client_config} =
-      if producer_opts[:shared_client] do
-        client = producer_opts[:client] || BroadwayKafka.BrodClient
+    client = producer_opts[:client] || BroadwayKafka.BrodClient
 
-        case client.init(Keyword.put(producer_opts, :broadway, opts)) do
-          {:error, message} ->
-            raise ArgumentError, "invalid options given to #{client}.init/1, " <> message
+    case client.init(Keyword.put(producer_opts, :broadway, opts)) do
+      {:error, message} ->
+        raise ArgumentError, "invalid options given to #{client}.init/1, " <> message
 
-          {:ok, config} = result ->
-            {client.shared_client_child_spec(config), result}
-        end
-      else
-        {[], nil}
-      end
+      {:ok, extra_child_specs, config} ->
+        new_producer_opts =
+          Keyword.put(producer_opts, :initialized_client_config, config)
 
-    new_producer_opts =
-      Keyword.put(producer_opts, :initialized_client_config, initialized_client_config)
+        updated_opts =
+          put_in(updated_opts, [:producer, :module], {producer_mod, new_producer_opts})
 
-    updated_opts = put_in(updated_opts, [:producer, :module], {producer_mod, new_producer_opts})
-
-    {allocators ++ extra_child_specs, updated_opts}
+        {allocators ++ extra_child_specs, updated_opts}
+    end
   end
 
   @impl :brod_group_member

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -33,16 +33,16 @@ defmodule BroadwayKafka.BrodClientTest do
       assert BrodClient.init(opts) == {:error, expected_msg <> ~s/"host:9092,"/}
 
       opts = Keyword.put(@opts, :hosts, host: 9092)
-      assert {:ok, %{hosts: [host: 9092]}} = BrodClient.init(opts)
+      assert {:ok, [], %{hosts: [host: 9092]}} = BrodClient.init(opts)
 
       opts = Keyword.put(@opts, :hosts, [{"host", 9092}])
-      assert {:ok, %{hosts: [{"host", 9092}]}} = BrodClient.init(opts)
+      assert {:ok, [], %{hosts: [{"host", 9092}]}} = BrodClient.init(opts)
 
       opts = Keyword.put(@opts, :hosts, "host:9092")
-      assert {:ok, %{hosts: [{"host", 9092}]}} = BrodClient.init(opts)
+      assert {:ok, [], %{hosts: [{"host", 9092}]}} = BrodClient.init(opts)
 
       opts = Keyword.put(@opts, :hosts, "host1:9092,host2:9092")
-      assert {:ok, %{hosts: [{"host1", 9092}, {"host2", 9092}]}} = BrodClient.init(opts)
+      assert {:ok, [], %{hosts: [{"host1", 9092}, {"host2", 9092}]}} = BrodClient.init(opts)
     end
 
     test ":group_id is a required string" do
@@ -55,7 +55,7 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :group_id to be a non empty string, got: :an_atom"}
 
       opts = Keyword.put(@opts, :group_id, "my_group")
-      assert {:ok, %{group_id: "my_group"}} = BrodClient.init(opts)
+      assert {:ok, [], %{group_id: "my_group"}} = BrodClient.init(opts)
     end
 
     test ":topics is a required list of strings" do
@@ -68,12 +68,12 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :topics to be a list of strings, got: :an_atom"}
 
       opts = Keyword.put(@opts, :topics, ["topic_1", "topic_2"])
-      assert {:ok, %{topics: ["topic_1", "topic_2"]}} = BrodClient.init(opts)
+      assert {:ok, [], %{topics: ["topic_1", "topic_2"]}} = BrodClient.init(opts)
     end
 
     test ":receive_interval is a non-negative integer with default value 2000" do
       opts = Keyword.delete(@opts, :receive_interval)
-      assert {:ok, %{receive_interval: 2000}} = BrodClient.init(opts)
+      assert {:ok, [], %{receive_interval: 2000}} = BrodClient.init(opts)
 
       opts = Keyword.put(@opts, :receive_interval, :an_atom)
 
@@ -81,11 +81,11 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :receive_interval to be a non-negative integer, got: :an_atom"}
 
       opts = Keyword.put(@opts, :receive_interval, 1000)
-      assert {:ok, %{receive_interval: 1000}} = BrodClient.init(opts)
+      assert {:ok, [], %{receive_interval: 1000}} = BrodClient.init(opts)
     end
 
     test ":reconnect_timeout is a non-negative integer with default value 1000" do
-      assert {:ok, %{reconnect_timeout: 1000}} = BrodClient.init(@opts)
+      assert {:ok, [], %{reconnect_timeout: 1000}} = BrodClient.init(@opts)
 
       opts = Keyword.put(@opts, :reconnect_timeout, :an_atom)
 
@@ -93,11 +93,11 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :reconnect_timeout to be a non-negative integer, got: :an_atom"}
 
       opts = Keyword.put(@opts, :reconnect_timeout, 2000)
-      assert {:ok, %{reconnect_timeout: 2000}} = BrodClient.init(opts)
+      assert {:ok, [], %{reconnect_timeout: 2000}} = BrodClient.init(opts)
     end
 
     test ":offset_commit_on_ack is a boolean with default value true" do
-      assert {:ok, %{offset_commit_on_ack: true}} = BrodClient.init(@opts)
+      assert {:ok, [], %{offset_commit_on_ack: true}} = BrodClient.init(@opts)
 
       opts = Keyword.put(@opts, :offset_commit_on_ack, :an_atom)
 
@@ -105,11 +105,11 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :offset_commit_on_ack to be a boolean, got: :an_atom"}
 
       opts = Keyword.put(@opts, :offset_commit_on_ack, false)
-      assert {:ok, %{offset_commit_on_ack: false}} = BrodClient.init(opts)
+      assert {:ok, [], %{offset_commit_on_ack: false}} = BrodClient.init(opts)
     end
 
     test ":offset_reset_policy can be :earliest or :latest. Default is :latest" do
-      assert {:ok, %{offset_reset_policy: :latest}} = BrodClient.init(@opts)
+      assert {:ok, [], %{offset_reset_policy: :latest}} = BrodClient.init(@opts)
 
       opts = Keyword.put(@opts, :offset_reset_policy, :an_atom)
 
@@ -118,14 +118,14 @@ defmodule BroadwayKafka.BrodClientTest do
                 "expected :offset_reset_policy to be one of [:earliest, :latest], got: :an_atom"}
 
       opts = Keyword.put(@opts, :offset_reset_policy, :earliest)
-      assert {:ok, %{offset_reset_policy: :earliest}} = BrodClient.init(opts)
+      assert {:ok, [], %{offset_reset_policy: :earliest}} = BrodClient.init(opts)
 
       opts = Keyword.put(@opts, :offset_reset_policy, :latest)
-      assert {:ok, %{offset_reset_policy: :latest}} = BrodClient.init(opts)
+      assert {:ok, [], %{offset_reset_policy: :latest}} = BrodClient.init(opts)
     end
 
     test ":begin_offset can be :assigned or :reset. Default is :assigned" do
-      assert {:ok, %{begin_offset: :assigned}} = BrodClient.init(@opts)
+      assert {:ok, [], %{begin_offset: :assigned}} = BrodClient.init(@opts)
 
       opts = Keyword.put(@opts, :begin_offset, :an_atom)
 
@@ -133,10 +133,10 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :begin_offset to be one of [:assigned, :reset], got: :an_atom"}
 
       opts = Keyword.put(@opts, :begin_offset, :assigned)
-      assert {:ok, %{begin_offset: :assigned}} = BrodClient.init(opts)
+      assert {:ok, [], %{begin_offset: :assigned}} = BrodClient.init(opts)
 
       opts = Keyword.put(@opts, :begin_offset, :reset)
-      assert {:ok, %{begin_offset: :reset}} = BrodClient.init(opts)
+      assert {:ok, [], %{begin_offset: :reset}} = BrodClient.init(opts)
     end
 
     test ":offset_commit_interval_seconds is an optional non-negative integer" do
@@ -148,7 +148,7 @@ defmodule BroadwayKafka.BrodClientTest do
                   "a positive integer, got: :an_atom"}
 
       opts = put_in(@opts, [:group_config, :offset_commit_interval_seconds], 3)
-      {:ok, %{group_config: group_config}} = BrodClient.init(opts)
+      {:ok, [], %{group_config: group_config}} = BrodClient.init(opts)
       assert group_config[:offset_commit_interval_seconds] == 3
     end
 
@@ -160,7 +160,7 @@ defmodule BroadwayKafka.BrodClientTest do
                 "expected :rejoin_delay_seconds to be a non-negative integer, got: :an_atom"}
 
       opts = put_in(@opts, [:group_config, :rejoin_delay_seconds], 3)
-      {:ok, %{group_config: group_config}} = BrodClient.init(opts)
+      {:ok, [], %{group_config: group_config}} = BrodClient.init(opts)
       assert group_config[:rejoin_delay_seconds] == 3
     end
 
@@ -172,7 +172,7 @@ defmodule BroadwayKafka.BrodClientTest do
                 "expected :session_timeout_seconds to be a positive integer, got: :an_atom"}
 
       opts = put_in(@opts, [:group_config, :session_timeout_seconds], 3)
-      {:ok, %{group_config: group_config}} = BrodClient.init(opts)
+      {:ok, [], %{group_config: group_config}} = BrodClient.init(opts)
       assert group_config[:session_timeout_seconds] == 3
     end
 
@@ -184,7 +184,7 @@ defmodule BroadwayKafka.BrodClientTest do
                 "expected :heartbeat_rate_seconds to be a positive integer, got: :an_atom"}
 
       opts = put_in(@opts, [:group_config, :heartbeat_rate_seconds], 3)
-      {:ok, %{group_config: group_config}} = BrodClient.init(opts)
+      {:ok, [], %{group_config: group_config}} = BrodClient.init(opts)
       assert group_config[:heartbeat_rate_seconds] == 3
     end
 
@@ -196,7 +196,7 @@ defmodule BroadwayKafka.BrodClientTest do
                 "expected :rebalance_timeout_seconds to be a positive integer, got: :an_atom"}
 
       opts = put_in(@opts, [:group_config, :rebalance_timeout_seconds], 3)
-      {:ok, %{group_config: group_config}} = BrodClient.init(opts)
+      {:ok, [], %{group_config: group_config}} = BrodClient.init(opts)
       assert group_config[:rebalance_timeout_seconds] == 3
     end
 
@@ -207,7 +207,7 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :min_bytes to be a positive integer, got: :an_atom"}
 
       opts = put_in(@opts, [:fetch_config, :min_bytes], 3)
-      {:ok, %{fetch_config: fetch_config}} = BrodClient.init(opts)
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(opts)
       assert fetch_config[:min_bytes] == 3
     end
 
@@ -218,7 +218,7 @@ defmodule BroadwayKafka.BrodClientTest do
                {:error, "expected :max_bytes to be a positive integer, got: :an_atom"}
 
       opts = put_in(@opts, [:fetch_config, :max_bytes], 3)
-      {:ok, %{fetch_config: fetch_config}} = BrodClient.init(opts)
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(opts)
       assert fetch_config[:max_bytes] == 3
     end
 
@@ -228,11 +228,11 @@ defmodule BroadwayKafka.BrodClientTest do
       assert BrodClient.init(opts) ==
                {:error, "expected :max_wait_time to be a positive integer, got: :an_atom"}
 
-      {:ok, %{fetch_config: fetch_config}} = BrodClient.init(@opts)
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(@opts)
       assert not Map.has_key?(fetch_config, :max_wait_time)
 
       opts = put_in(@opts, [:fetch_config, :max_wait_time], 3)
-      {:ok, %{fetch_config: fetch_config}} = BrodClient.init(opts)
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(opts)
       assert fetch_config[:max_wait_time] == 3
     end
 
@@ -244,7 +244,7 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = put_in(@opts, [:client_config, :client_id_prefix], "a string")
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [
                   client_id_prefix: "a string"
@@ -267,7 +267,7 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = put_in(@opts, [:client_config, :sasl], {:plain, "username", "password"})
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [
                   sasl: {:plain, "username", "password"}
@@ -278,7 +278,7 @@ defmodule BroadwayKafka.BrodClientTest do
     test ":sasl is an optional tuple of :callback, SASL Authentication Plugin module and opts" do
       opts = put_in(@opts, [:client_config, :sasl], {:callback, FakeSaslMechanismPlugin, {}})
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [
                   sasl: {:callback, FakeSaslMechanismPlugin, {}}
@@ -300,7 +300,7 @@ defmodule BroadwayKafka.BrodClientTest do
           certfile: "client.crt"
         )
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [
                   ssl: [cacertfile: "ca.crt", keyfile: "client.key", certfile: "client.crt"]
@@ -309,7 +309,7 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = put_in(@opts, [:client_config, :ssl], true)
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [ssl: true]
               }} = BrodClient.init(opts)
@@ -323,7 +323,7 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = put_in(@opts, [:client_config, :connect_timeout], 5000)
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [
                   connect_timeout: 5000
@@ -345,7 +345,7 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = put_in(@opts, [:client_config, :request_timeout], 5000)
 
-      assert {:ok,
+      assert {:ok, [],
               %{
                 client_config: [
                   request_timeout: 5000
@@ -361,7 +361,7 @@ defmodule BroadwayKafka.BrodClientTest do
 
       opts = put_in(@opts, [:client_config, :query_api_versions], false)
 
-      assert {:ok, %{client_config: [query_api_versions: false]}} = BrodClient.init(opts)
+      assert {:ok, [], %{client_config: [query_api_versions: false]}} = BrodClient.init(opts)
     end
 
     test ":shared_client is an optional boolean" do
@@ -376,7 +376,7 @@ defmodule BroadwayKafka.BrodClientTest do
         |> Keyword.put(:broadway, name: :my_broadway_name)
         |> put_in([:client_config, :client_id_prefix], "my_prefix.")
 
-      assert {:ok, %{shared_client: true}} = BrodClient.init(opts)
+      assert {:ok, _specs, %{shared_client: true}} = BrodClient.init(opts)
     end
 
     test "return shared_client_id when :shared_client is true" do
@@ -386,42 +386,12 @@ defmodule BroadwayKafka.BrodClientTest do
         |> Keyword.put(:broadway, name: :my_broadway_name)
         |> put_in([:client_config, :client_id_prefix], "my_prefix.")
 
-      assert {:ok,
+      assert {:ok, child_specs,
               %{
                 shared_client: true,
                 shared_client_id: :"my_prefix.Elixir.my_broadway_name.SharedClient"
               }} =
                BrodClient.init(opts)
-
-      opts =
-        @opts
-        |> Keyword.put(:shared_client, false)
-        |> Keyword.put(:broadway, name: :my_broadway_name)
-        |> put_in([:client_config, :client_id_prefix], "my_prefix.")
-
-      assert {:ok,
-              %{
-                shared_client: false,
-                shared_client_id: nil
-              }} =
-               BrodClient.init(opts)
-    end
-  end
-
-  describe "shared_client_child_spec" do
-    test "should return child spec" do
-      module_opts =
-        @opts
-        |> Keyword.put(:shared_client, true)
-        |> Keyword.put(:client_config, client_id_prefix: "my_prefix.")
-
-      broadway_opts = [
-        name: :my_broadway
-      ]
-
-      {:ok, config} = BrodClient.init(Keyword.put(module_opts, :broadway, broadway_opts))
-
-      assert child_specs = BrodClient.shared_client_child_spec(config)
 
       assert [
                %{
@@ -431,8 +401,21 @@ defmodule BroadwayKafka.BrodClientTest do
              ] = child_specs
 
       assert [{:host, 9092}] = hosts
-      assert :"my_prefix.Elixir.my_broadway.SharedClient" = shared_client_id
+      assert :"my_prefix.Elixir.my_broadway_name.SharedClient" = shared_client_id
       assert [client_id_prefix: "my_prefix."] = client_config
+
+      opts =
+        @opts
+        |> Keyword.put(:shared_client, false)
+        |> Keyword.put(:broadway, name: :my_broadway_name)
+        |> put_in([:client_config, :client_id_prefix], "my_prefix.")
+
+      assert {:ok, [],
+              %{
+                shared_client: false,
+                shared_client_id: nil
+              }} =
+               BrodClient.init(opts)
     end
   end
 

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -408,32 +408,20 @@ defmodule BroadwayKafka.BrodClientTest do
     end
   end
 
-  describe "prepare for start" do
-    test "should return an empty list and unchanged opts when shared_client is not true" do
-      broadway_opts = [
-        name: :my_broadway,
-        producer: [
-          module: {BroadwayKafka.Producer, @opts}
-        ]
-      ]
-
-      assert {[], ^broadway_opts} = BrodClient.prepare_for_start(broadway_opts)
-    end
-
-    test "should return :brod_client child spec and unchanged opts when shared_client is true" do
+  describe "shared_client_child_spec" do
+    test "should return child spec" do
       module_opts =
         @opts
         |> Keyword.put(:shared_client, true)
         |> Keyword.put(:client_config, client_id_prefix: "my_prefix.")
 
       broadway_opts = [
-        name: :my_broadway,
-        producer: [
-          module: {BroadwayKafka.Producer, module_opts}
-        ]
+        name: :my_broadway
       ]
 
-      assert {child_specs, ^broadway_opts} = BrodClient.prepare_for_start(broadway_opts)
+      {:ok, config} = BrodClient.init(Keyword.put(module_opts, :broadway, broadway_opts))
+
+      assert child_specs = BrodClient.shared_client_child_spec(config)
 
       assert [
                %{

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -269,3 +269,266 @@ defmodule BroadwayKafka.ConsumerTest do
     end)
   end
 end
+
+defmodule BroadwayKafka.ConsumerSharedClientTest do
+  @moduledoc """
+  Kafka integration tests.
+
+  # Setup
+
+  1. Run Docker
+     $ docker compose up -d
+
+  # Running only integration tests
+
+      mix test --only integration
+
+  # Running all tests
+
+      mix test --include integration
+  """
+
+  use ExUnit.Case
+  require Logger
+
+  @moduletag :integration
+
+  alias BroadwayKafka.ConsumerTest.Config
+
+  defmodule MyBroadway do
+    use Broadway
+
+    alias BroadwayKafka.ConsumerTest.Config
+
+    def start_link(context) do
+      Broadway.start_link(__MODULE__,
+        name: __MODULE__,
+        context: context,
+        producer: [
+          module:
+            {BroadwayKafka.Producer,
+             [
+               hosts: [localhost: 9092],
+               group_id: "brod_my_group",
+               topics: ["test"],
+               receive_interval: 100,
+               group_config: [
+                 offset_commit_interval_seconds: 1,
+                 rejoin_delay_seconds: 2
+               ],
+               fetch_config: [
+                 max_bytes: 10_240
+               ],
+               shared_client: true
+             ]},
+          concurrency: 3
+        ],
+        processors: [
+          default: [
+            concurrency: 3
+          ]
+        ],
+        batchers: [
+          default: [
+            batch_size: 20,
+            batch_timeout: 50,
+            concurrency: 4
+          ]
+        ]
+      )
+    end
+
+    def handle_message(_, message, %{caller_pid: caller_pid}) do
+      if message.data in Config.last_messages() do
+        send(caller_pid, {:last_message, message.metadata.partition, message.data})
+      end
+
+      message
+    end
+
+    def handle_batch(_, messages, _info, %{messages_agent: messages_agent}) do
+      Agent.update(messages_agent, fn list -> list ++ messages end)
+      last_message = List.last(messages)
+      last_offset = last_message.metadata.offset
+      partition = last_message.metadata.partition
+
+      IO.puts(
+        "Batch handled with #{length(messages)} messages. " <>
+          "Partition: #{partition} Last offset: #{last_offset}"
+      )
+
+      messages
+    end
+  end
+
+  setup_all do
+    topic = "test"
+    hosts = [localhost: 9092]
+
+    reset_topic(topic)
+
+    {broadway_pid, messages_agent} = start_broadway()
+
+    # Let's wait for the assignments before start sending messages
+    wait_for_assignments(MyBroadway)
+
+    IO.puts("Sending messages...")
+    send_messages(Config.n_messages(), hosts, topic)
+
+    [last_message_2, last_message_0, last_message_1] = Config.last_messages()
+
+    receive do
+      {:last_message, 2, ^last_message_2} ->
+        IO.puts("Got last message from partition 2")
+    end
+
+    receive do
+      {:last_message, 0, ^last_message_0} ->
+        IO.puts("Got last message from partition 0")
+    end
+
+    receive do
+      {:last_message, 1, ^last_message_1} ->
+        IO.puts("Got last message from partition 1")
+    end
+
+    # Let's wait a bit to see if we get more messages
+    Process.sleep(1000)
+
+    messages = Agent.get(messages_agent, & &1)
+
+    on_exit(fn ->
+      stop_broadway(broadway_pid)
+    end)
+
+    {:ok, %{broadway_pid: broadway_pid, messages: messages}}
+  end
+
+  test "number of processed messages = total messages ", %{messages: messages} do
+    assert length(messages) == Config.n_messages()
+  end
+
+  test "messages are not duplicated", %{messages: messages} do
+    messages_with_count =
+      Enum.reduce(messages, %{}, fn msg, acc ->
+        Map.update(acc, msg.data, %{count: 1, list: [msg]}, fn %{count: count, list: list} ->
+          %{list: [msg | list], count: count + 1}
+        end)
+      end)
+
+    duplicated_messages = Enum.filter(messages_with_count, fn {_k, v} -> v.count > 1 end)
+
+    assert duplicated_messages == []
+  end
+
+  test "order of messages and offsets", %{messages: messages} do
+    assert get_ordering_proplems(messages) == []
+  end
+
+  defp reset_topic(topic) do
+    brokers = [{"localhost", 9092}]
+
+    :brod.delete_topics(brokers, [topic], 1_000)
+
+    topic_config = [
+      %{
+        num_partitions: 3,
+        replication_factor: 1,
+        name: topic,
+        assignments: [],
+        configs: []
+      }
+    ]
+
+    wait_until_create_topic(brokers, topic_config, %{timeout: 1_000})
+  end
+
+  defp wait_until_create_topic(brokers, topic_config, opts) do
+    case :brod.create_topics(brokers, topic_config, opts) do
+      :ok ->
+        :ok
+
+      _error ->
+        Process.sleep(10)
+        wait_until_create_topic(brokers, topic_config, opts)
+    end
+  end
+
+  defp send_messages(n_messages, hosts, topic) do
+    client_id = :test_client
+    :ok = :brod.start_client(hosts, client_id, _client_config = [])
+    :ok = :brod.start_producer(client_id, topic, _producer_config = [])
+
+    Enum.each(1..n_messages, fn i ->
+      partition = rem(i, 3)
+      :ok = :brod.produce_sync(client_id, topic, partition, _key = "", "#{i}")
+    end)
+
+    :brod.stop_client(client_id)
+  end
+
+  defp start_broadway() do
+    {:ok, messages_agent} = Agent.start_link(fn -> [] end)
+    context = %{messages_agent: messages_agent, caller_pid: self()}
+    {:ok, broadway_pid} = MyBroadway.start_link(context)
+    {broadway_pid, messages_agent}
+  end
+
+  defp stop_broadway(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :normal)
+
+    receive do
+      {:DOWN, ^ref, _, _, _} -> :ok
+    end
+  end
+
+  defp get_ordering_proplems(messages) do
+    init_acc = %{last_messages: %{0 => nil, 1 => nil, 2 => nil}, problems: []}
+
+    %{problems: ordering_problems} =
+      Enum.reduce(messages, init_acc, fn msg, acc ->
+        %{last_messages: last_messages, problems: problems} = acc
+        partition = msg.metadata.partition
+
+        problems =
+          case last_messages[partition] do
+            nil ->
+              problems
+
+            last_message ->
+              if String.to_integer(msg.data) <= String.to_integer(last_message.data) do
+                message =
+                  "Data out of order #{msg.data}->#{last_message.data} in partition #{partition}"
+
+                [message | problems]
+              else
+                problems
+              end
+          end
+
+        last_messages = Map.put(last_messages, partition, msg)
+        %{acc | problems: Enum.reverse(problems), last_messages: last_messages}
+      end)
+
+    Enum.reverse(ordering_problems)
+  end
+
+  defp wait_for_assignments(broadway_name) do
+    producers =
+      broadway_name
+      |> Broadway.producer_names()
+      |> Enum.map(fn producer ->
+        pid = Process.whereis(producer)
+        :erlang.trace(pid, true, [:receive, tracer: self()])
+        pid
+      end)
+
+    Enum.each(producers, fn pid ->
+      receive do
+        {:trace, ^pid, :receive, {:put_assignments, _, _}} ->
+          IO.puts("Assignment received. Producer: #{inspect(pid)}")
+      end
+    end)
+  end
+end

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -130,7 +130,7 @@ defmodule BroadwayKafka.ConsumerTest do
     end
 
     # Let's wait a bit to see if we get more messages
-    Process.sleep(1000)
+    Process.sleep(2000)
 
     messages = Agent.get(messages_agent, & &1)
 
@@ -393,7 +393,7 @@ defmodule BroadwayKafka.ConsumerSharedClientTest do
     end
 
     # Let's wait a bit to see if we get more messages
-    Process.sleep(1000)
+    Process.sleep(2000)
 
     messages = Agent.get(messages_agent, & &1)
 

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -309,8 +309,8 @@ defmodule BroadwayKafka.ConsumerSharedClientTest do
             {BroadwayKafka.Producer,
              [
                hosts: [localhost: 9092],
-               group_id: "brod_my_group",
-               topics: ["test"],
+               group_id: "brod_my_group_2",
+               topics: ["test_2"],
                receive_interval: 100,
                group_config: [
                  offset_commit_interval_seconds: 1,
@@ -362,7 +362,7 @@ defmodule BroadwayKafka.ConsumerSharedClientTest do
   end
 
   setup_all do
-    topic = "test"
+    topic = "test_2"
     hosts = [localhost: 9092]
 
     reset_topic(topic)


### PR DESCRIPTION
Context: https://github.com/dashbitco/broadway_kafka/issues/132

First attempt to solve the related issue. Let me know what you think! :smile: 

Some considerations:

- Currently, for non shared clients, the client_id is harded coded inside the producer module. I've implemented it differently for shared clients, it is returned by the `init/1` callback implemented by the client because I need it there in order to return the proper child_spec on the new added callback. Is this difference ok?
- I'm not sure we really need one brod_group_coordinator per producer, but since it is way lighter than the client we can leave it there for now
-  When `shared_client` is `false` the clients are being started under brod's supervisor but when it is `true` it is started under broadway supervision tree. Is that ok? I had a tricky bug because of this difference. (left a comment on the code about it)