### PR TITLE
`brod` supports sasl credentials from file

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -297,14 +297,14 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:sasl, value = {:callback, _callback_module, _opts}),
     do: {:ok, value}
 
-  defp validate_option(:sasl, {mechanism, username, password})
+  defp validate_option(:sasl, {mechanism, username, password} = value)
        when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
               is_binary(username) and
               is_binary(password) do
     {:ok, value}
   end
 
-  defp validate_option(:sasl, {mechanism, path})
+  defp validate_option(:sasl, {mechanism, path} = value)
        when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
               is_binary(path) do
     {:ok, value}

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -297,15 +297,21 @@ defmodule BroadwayKafka.BrodClient do
   defp validate_option(:sasl, value = {:callback, _callback_module, _opts}),
     do: {:ok, value}
 
-  defp validate_option(:sasl, value) do
-    with {mechanism, username, password}
-         when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
+  defp validate_option(:sasl, {mechanism, username, password})
+      when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
                 is_binary(username) and
-                is_binary(password) <- value do
-      {:ok, value}
-    else
-      _value -> validation_error(:sasl, "a tuple of SASL mechanism, username and password", value)
-    end
+                is_binary(password) do
+    {:ok, value}
+  end
+
+  defp validate_option(:sasl, {mechanism, path})
+      when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
+                is_binary(path) do
+    {:ok, value}
+  end
+
+  defp validate_option(:sasl, value) do
+    validation_error(:sasl, "a tuple of SASL mechanism, username and password, or mechanism and path", value)
   end
 
   defp validate_option(:query_api_versions, value) when not is_boolean(value),

--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -298,20 +298,24 @@ defmodule BroadwayKafka.BrodClient do
     do: {:ok, value}
 
   defp validate_option(:sasl, {mechanism, username, password})
-      when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
-                is_binary(username) and
-                is_binary(password) do
+       when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
+              is_binary(username) and
+              is_binary(password) do
     {:ok, value}
   end
 
   defp validate_option(:sasl, {mechanism, path})
-      when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
-                is_binary(path) do
+       when mechanism in [:plain, :scram_sha_256, :scram_sha_512] and
+              is_binary(path) do
     {:ok, value}
   end
 
   defp validate_option(:sasl, value) do
-    validation_error(:sasl, "a tuple of SASL mechanism, username and password, or mechanism and path", value)
+    validation_error(
+      :sasl,
+      "a tuple of SASL mechanism, username and password, or mechanism and path",
+      value
+    )
   end
 
   defp validate_option(:query_api_versions, value) when not is_boolean(value),

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -257,13 +257,13 @@ defmodule BroadwayKafka.BrodClientTest do
 
       assert BrodClient.init(opts) ==
                {:error,
-                "expected :sasl to be a tuple of SASL mechanism, username and password, got: :an_atom"}
+                "expected :sasl to be a tuple of SASL mechanism, username and password, or mechanism and path, got: :an_atom"}
 
       opts = put_in(@opts, [:client_config, :sasl], {:an_atom, "username", "password"})
 
       assert BrodClient.init(opts) ==
                {:error,
-                "expected :sasl to be a tuple of SASL mechanism, username and password, got: {:an_atom, \"username\", \"password\"}"}
+                "expected :sasl to be a tuple of SASL mechanism, username and password, or mechanism and path, got: {:an_atom, \"username\", \"password\"}"}
 
       opts = put_in(@opts, [:client_config, :sasl], {:plain, "username", "password"})
 
@@ -271,6 +271,15 @@ defmodule BroadwayKafka.BrodClientTest do
               %{
                 client_config: [
                   sasl: {:plain, "username", "password"}
+                ]
+              }} = BrodClient.init(opts)
+
+      opts = put_in(@opts, [:client_config, :sasl], {:plain, "filepath"})
+
+      assert {:ok, [],
+              %{
+                client_config: [
+                  sasl: {:plain, "filepath"}
                 ]
               }} = BrodClient.init(opts)
     end
@@ -390,8 +399,7 @@ defmodule BroadwayKafka.BrodClientTest do
               %{
                 shared_client: true,
                 shared_client_id: :"my_prefix.Elixir.my_broadway_name.SharedClient"
-              }} =
-               BrodClient.init(opts)
+              }} = BrodClient.init(opts)
 
       assert [
                %{
@@ -414,8 +422,7 @@ defmodule BroadwayKafka.BrodClientTest do
               %{
                 shared_client: false,
                 shared_client_id: nil
-              }} =
-               BrodClient.init(opts)
+              }} = BrodClient.init(opts)
     end
   end
 


### PR DESCRIPTION
Hi folks! This PR adds support for file-based sasl credentials. From `brod` readme (https://github.com/kafka4beam/brod/blob/master/README.md?plain=1#L425-L428) (emphasis mine):

> brod supports SASL `PLAIN`, `SCRAM-SHA-256` and `SCRAM-SHA-512` authentication mechanisms out of the box. To use it, add `{sasl, {Mechanism, Username, Password}}` **or `{sasl, {Mechanism, File}}`** to client config. Where `Mechanism` is `plain | scram_sha_256 | scram_sha_512`, and **`File` is the path to a text file
which contains two lines, first line for username and second line for password**