### PR TITLE
Support for IPv6

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -29,7 +29,8 @@ defmodule BroadwayKafka.BrodClient do
     :connect_timeout,
     :request_timeout,
     :client_id_prefix,
-    :query_api_versions
+    :query_api_versions,
+    :extra_sock_opts
   ]
 
   @default_receive_interval 2000

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -139,6 +139,9 @@ defmodule BroadwayKafka.Producer do
     * `:request_timeout` - Optional. Time in milliseconds to be used as a timeout for waiting response from Kafka.
     Default is to use `:brod`'s default timeout which is currently 240 seconds.
 
+    * `:extra_sock_opts` - Optional. `gen_tcp` socket options. [More info](https://www.erlang.org/doc/man/gen_tcp.html#type-option).
+    Set to `[:inet6]` if your Kafka broker uses IPv6.
+
   > **Note**: Currently, Broadway does not support all options provided by `:brod`. If you
   have a scenario where you need any extra option that is not listed above, please open an
   issue, so we can consider adding it.


### PR DESCRIPTION
For my Staging environment, I have Redpanda running on fly.io, and I could not connect it to Broadway because only IPv6 addresses are available within fly.io internal network (or I couldn't figure out how to enable IPv4).

The workaround was to use `extra_sock_opts: [:inet6]` documented  [here](https://hexdocs.pm/brod/brod.html#start_client/3) (with `:inet6` value documented [here](https://www.erlang.org/doc/man/gen_tcp.html#connect-4) )

This PR white-lists and documents `extra_sock_opts` within available `client_config`.