### PR TITLE
Add kafka lag query

### DIFF
--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -58,19 +58,18 @@ defmodule BroadwayKafka.KafkaClient do
   @callback fetch_kafka_lag(:brod.client(), :brod.group_id(), [:brod.endpoint()]) ::
               {:ok,
                [
-                 %{
-                   topic: String.t(),
-                   offsets: [
-                     {:ok,
-                      %{
-                        partition_index: non_neg_integer(),
-                        lag: non_neg_integer(),
-                        committed_offset: non_neg_integer(),
-                        partition_offset: non_neg_integer()
-                      }}
-                     | {:error, any()}
-                   ]
+                 {
+                   :ok,
+                   %{
+                     topic: String.t(),
+                     partition_index: non_neg_integer(),
+                     lag: non_neg_integer(),
+                     committed_offset: non_neg_integer(),
+                     partition_offset: non_neg_integer()
+                   }
                  }
+                 | {:error, any()}
+                 | {:exit, :timeout}
                ]}
               | {:error, any()}
 end

--- a/lib/broadway_kafka/kafka_client.ex
+++ b/lib/broadway_kafka/kafka_client.ex
@@ -55,4 +55,22 @@ defmodule BroadwayKafka.KafkaClient do
   @callback update_topics(brod_group_coordinator(), [:brod.topic()]) :: :ok
   @callback connected?(:brod.client()) :: boolean
   @callback disconnect(:brod.client()) :: :ok
+  @callback fetch_kafka_lag(:brod.client(), :brod.group_id(), [:brod.endpoint()]) ::
+              {:ok,
+               [
+                 %{
+                   topic: String.t(),
+                   offsets: [
+                     {:ok,
+                      %{
+                        partition_index: non_neg_integer(),
+                        lag: non_neg_integer(),
+                        committed_offset: non_neg_integer(),
+                        partition_offset: non_neg_integer()
+                      }}
+                     | {:error, any()}
+                   ]
+                 }
+               ]}
+              | {:error, any()}
 end

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -581,7 +581,7 @@ defmodule BroadwayKafka.Producer do
     :ok
   end
 
-  @spec fetch_kafka_lag(pid()) ::
+  @spec fetch_kafka_lag(pid() | atom()) ::
           {:ok,
            [
              %{
@@ -602,10 +602,11 @@ defmodule BroadwayKafka.Producer do
   @doc """
   Fetch the current offset of processed messages and the total number of messages
   (`partition_offset`) for each partition and each topic the producer is consuming. Lag is the
-  difference between them. Calling this can be slow.
+  difference between them. To get the producer pid, you can pick any process returned by
+  `Broadway.producer_names`. Calling this can be slow.
   """
-  def fetch_kafka_lag(pid) do
-    GenStage.call(pid, :fetch_kafka_lag, :infinity)
+  def fetch_kafka_lag(pid_or_name) do
+    GenStage.call(pid_or_name, :fetch_kafka_lag, :infinity)
   end
 
   defp maybe_schedule_poll(%{demand: 0} = state, _interval) do

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -322,33 +322,9 @@ defmodule BroadwayKafka.Producer do
   end
 
   def handle_call(:fetch_kafka_lag, _from, state) do
-    with {:ok, kafka_offsets} <-
-           :brod.fetch_committed_offsets(state.client_id, state.config.group_id) do
-      {:reply,
-       {:ok,
-        Enum.map(kafka_offsets, fn topic ->
-          %{
-            topic: topic.name,
-            offsets:
-              Enum.map(topic.partitions, fn partition ->
-                with {:ok, partition_offset} <-
-                       :brod.resolve_offset(
-                         state.config.hosts,
-                         topic.name,
-                         partition.partition_index
-                       ) do
-                  {:ok,
-                   %{
-                     partition_index: partition.partition_index,
-                     lag: partition_offset - partition.committed_offset,
-                     committed_offset: partition.committed_offset,
-                     partition_offset: partition_offset
-                   }}
-                end
-              end)
-          }
-        end)}, [], state}
-    end
+    {:reply,
+     state.client.fetch_kafka_lag(state.client_id, state.config.group_id, state.config.hosts), [],
+     state}
   end
 
   @impl GenStage


### PR DESCRIPTION
Proposal to resolve #145 . Not doing through telemetry because I  could not see a good trigger for this. We would probably prefer calling it on a timer explicitly.

Not sure if extending the client behaviour for this is ideal though.