### PR TITLE
Preserve offsets set semantics

### DIFF
--- a/lib/broadway_kafka/acknowledger.ex
+++ b/lib/broadway_kafka/acknowledger.ex
@@ -58,7 +58,8 @@ defmodule BroadwayKafka.Acknowledger do
   @spec update_last_offset(t, key, :brod.offset(), seen_offsets) :: t
   def update_last_offset(acknowledgers, key, last_offset, new_offsets) do
     %{^key => {pending, _, seen}} = acknowledgers
-    %{acknowledgers | key => {pending ++ new_offsets, last_offset, seen}}
+    new_pending = :ordsets.union(pending, :ordsets.from_list(new_offsets))
+    %{acknowledgers | key => {new_pending, last_offset, seen}}
   end
 
   @doc """

--- a/test/acknowledger_test.exs
+++ b/test/acknowledger_test.exs
@@ -46,6 +46,16 @@ defmodule BroadwayKafka.AcknowledgerTest do
     assert {true, 19, _} = Ack.update_current_offset(ack, @foo, [17])
   end
 
+  test "update_last_offset preserves set semantics with overlapping offsets" do
+    # Publish 10..14, acknowledge 10..12.
+    ack = Ack.update_last_offset(@ack, @foo, 15, Enum.to_list(10..14))
+    assert {false, 12, ack} = Ack.update_current_offset(ack, @foo, [10, 11, 12])
+
+    # Publish 13..17 (overlapping with previous), acknowledge all.
+    ack = Ack.update_last_offset(ack, @foo, 18, Enum.to_list(13..17))
+    assert {true, 17, _} = Ack.update_current_offset(ack, @foo, [13, 14, 15, 16, 17])
+  end
+
   test "update_current_offset with gaps" do
     ack = Ack.update_last_offset(@ack, @foo, 20, [11, 13, 15, 17, 19])
     assert {true, 19, _} = Ack.update_current_offset(ack, @foo, [9, 11, 13, 15, 17, 19])


### PR DESCRIPTION
In #139 we saw that offsets can accumulate in the producer state, blocking consumption of messages. This can occur when 'new' offsets are added but which are already being tracked, which results in an invariant being broken (that offsets are unique) which blocks processing.

This PR restores the invariant by maintaining the offset list as an ordered set, thus removing duplicates.

There's a new test which fails without the library change and passes with it.

```
  1) test update_last_offset preserves set semantics with overlapping offsets (BroadwayKafka.AcknowledgerTest)
     test/acknowledger_test.exs:49
     match (=) failed
     code:  assert {true, 17, _} = Ack.update_current_offset(ack, @foo, [13, 14, 15, 16, 17])
     left:  {true, 17, _}
     right: {false, nil, %{{1, "bar", 2} => {[], 0, []}, {1, "foo", 1} => {[13, 14, 15, 16, 17], 18, [15, 16, 17]}}}
     stacktrace:
       test/acknowledger_test.exs:57: (test)
```