### PR TITLE
Retry Kafka retriable errors

### DIFF
--- a/lib/broadway_kafka/brod_client.ex
+++ b/lib/broadway_kafka/brod_client.ex
@@ -51,6 +51,10 @@ defmodule BroadwayKafka.BrodClient do
 
   @impl true
   def fetch(client_id, topic, partition, offset, opts, _config) do
+    # These options drive BroadwayKafka's own retry logic and are not valid
+    # :brod.fetch/5 options.
+    opts = Map.drop(opts, [:max_fetch_retries, :fetch_retry_backoff_ms])
+
     :brod.fetch(client_id, topic, partition, offset, opts)
   end
 

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -131,9 +131,6 @@ defmodule BroadwayKafka.Producer do
     :replica_not_available
   ]
 
-  @default_max_fetch_retries 3
-  @default_fetch_retry_backoff_ms 500
-
   @impl GenStage
   def init(opts) do
     Process.flag(:trap_exit, true)
@@ -531,14 +528,12 @@ defmodule BroadwayKafka.Producer do
       config: config
     } = state
 
-    max_retries = Keyword.get(config, :max_fetch_retries, @default_max_fetch_retries)
+    fetch_config = config[:fetch_config]
+    max_retries = fetch_config[:max_fetch_retries]
 
-    case client.fetch(client_id, topic, partition, offset, config[:fetch_config], config) do
+    case client.fetch(client_id, topic, partition, offset, fetch_config, config) do
       {:error, reason} when reason in @retriable_fetch_errors and attempt < max_retries ->
-        backoff_ms =
-          config
-          |> Keyword.get(:fetch_retry_backoff_ms, @default_fetch_retry_backoff_ms)
-          |> then(&(&1 * Integer.pow(2, attempt)))
+        backoff_ms = fetch_config[:fetch_retry_backoff_ms] * Integer.pow(2, attempt)
 
         Logger.warning(
           "Retriable error while fetching records from Kafka (topic=#{topic} " <>

--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -118,6 +118,22 @@ defmodule BroadwayKafka.Producer do
   defrecordp :brod_received_assignment,
              extract(:brod_received_assignment, from_lib: "brod/include/brod.hrl")
 
+  # Protocol error codes that indicate a transient condition on the broker.
+  # Retrying the fetch in place avoids crashing the producer, which would
+  # force a rebalance of the whole consumer group.
+  @retriable_fetch_errors [
+    :kafka_storage_error,
+    :leader_not_available,
+    :not_leader_for_partition,
+    :not_leader_or_follower,
+    :request_timed_out,
+    :network_exception,
+    :replica_not_available
+  ]
+
+  @default_max_fetch_retries 3
+  @default_fetch_retry_backoff_ms 500
+
   @impl GenStage
   def init(opts) do
     Process.flag(:trap_exit, true)
@@ -494,15 +510,9 @@ defmodule BroadwayKafka.Producer do
   end
 
   defp fetch_messages_from_kafka(state, key, offset) do
-    %{
-      client: client,
-      client_id: client_id,
-      config: config
-    } = state
-
     {generation_id, topic, partition} = key
 
-    case client.fetch(client_id, topic, partition, offset, config[:fetch_config], config) do
+    case fetch_with_retries(state, topic, partition, offset, 0) do
       {:ok, {_watermark_offset, kafka_messages}} ->
         Enum.map(kafka_messages, fn k_msg ->
           wrap_message(k_msg, topic, partition, generation_id)
@@ -511,6 +521,36 @@ defmodule BroadwayKafka.Producer do
       {:error, reason} ->
         raise "cannot fetch records from Kafka (topic=#{topic} partition=#{partition} " <>
                 "offset=#{offset}). Reason: #{inspect(reason)}"
+    end
+  end
+
+  defp fetch_with_retries(state, topic, partition, offset, attempt) do
+    %{
+      client: client,
+      client_id: client_id,
+      config: config
+    } = state
+
+    max_retries = Keyword.get(config, :max_fetch_retries, @default_max_fetch_retries)
+
+    case client.fetch(client_id, topic, partition, offset, config[:fetch_config], config) do
+      {:error, reason} when reason in @retriable_fetch_errors and attempt < max_retries ->
+        backoff_ms =
+          config
+          |> Keyword.get(:fetch_retry_backoff_ms, @default_fetch_retry_backoff_ms)
+          |> then(&(&1 * Integer.pow(2, attempt)))
+
+        Logger.warning(
+          "Retriable error while fetching records from Kafka (topic=#{topic} " <>
+            "partition=#{partition} offset=#{offset}). Reason: #{inspect(reason)}. " <>
+            "Retrying in #{backoff_ms}ms (attempt #{attempt + 1} of #{max_retries})"
+        )
+
+        Process.sleep(backoff_ms)
+        fetch_with_retries(state, topic, partition, offset, attempt + 1)
+
+      result ->
+        result
     end
   end
 

--- a/lib/broadway_kafka/producer_options.ex
+++ b/lib/broadway_kafka/producer_options.ex
@@ -73,6 +73,24 @@ defmodule BroadwayKafka.ProducerOptions do
       doc: """
       The most time (in millisecond) that the broker may wait for `:min_bytes` of data.
       """
+    ],
+    max_fetch_retries: [
+      type: :non_neg_integer,
+      default: 3,
+      doc: """
+      How many times a failed fetch is retried in place when Kafka returns a retriable error,
+      before the producer raises as it does for any other error. Set to `0` to disable retries.
+      BroadwayKafka uses this option itself and does not pass it to `:brod.fetch/5`.
+      """
+    ],
+    fetch_retry_backoff_ms: [
+      type: :non_neg_integer,
+      default: 500,
+      doc: """
+      The time, in milliseconds, to wait before the first retry of a failed fetch
+      (see `:max_fetch_retries`). The wait time doubles on each later retry. BroadwayKafka uses
+      this option itself and does not pass it to `:brod.fetch/5`.
+      """
     ]
   ]
 

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -268,6 +268,38 @@ defmodule BroadwayKafka.BrodClientTest do
       assert fetch_config[:max_wait_time] == 3000
     end
 
+    test ":max_fetch_retries is an optional non-negative integer" do
+      opts = put_in(@opts, [:fetch_config, :max_fetch_retries], :an_atom)
+
+      assert_opt_error(
+        opts,
+        "expected :max_fetch_retries to be a non negative integer, got: :an_atom"
+      )
+
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(@opts)
+      assert fetch_config[:max_fetch_retries] == 3
+
+      opts = put_in(@opts, [:fetch_config, :max_fetch_retries], 0)
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(opts)
+      assert fetch_config[:max_fetch_retries] == 0
+    end
+
+    test ":fetch_retry_backoff_ms is an optional non-negative integer" do
+      opts = put_in(@opts, [:fetch_config, :fetch_retry_backoff_ms], :an_atom)
+
+      assert_opt_error(
+        opts,
+        "expected :fetch_retry_backoff_ms to be a non negative integer, got: :an_atom"
+      )
+
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(@opts)
+      assert fetch_config[:fetch_retry_backoff_ms] == 500
+
+      opts = put_in(@opts, [:fetch_config, :fetch_retry_backoff_ms], 100)
+      {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(opts)
+      assert fetch_config[:fetch_retry_backoff_ms] == 100
+    end
+
     test ":client_id_prefix is an optional atom value" do
       opts = put_in(@opts, [:client_config, :client_id_prefix], :wrong_type)
 

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -792,7 +792,7 @@ defmodule BroadwayKafka.ProducerTest do
                begin_offset: :assigned,
                ack_raises_on_offset: ack_raises_on_offset,
                fetch_errors_agent: Keyword.get(opts, :fetch_errors_agent),
-               fetch_retry_backoff_ms: 0,
+               fetch_config: [max_fetch_retries: 3, fetch_retry_backoff_ms: 0],
                shared_client: opts[:shared_client] || false,
                child_specs: opts[:child_specs] || []
              ]},

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -59,6 +59,26 @@ defmodule BroadwayKafka.ProducerTest do
 
     @impl true
     def fetch(_client_id, topic, partition, offset, _opts, config) do
+      case pop_fetch_error(config) do
+        nil ->
+          do_fetch(topic, partition, offset, config)
+
+        reason ->
+          send(config[:test_pid], {:fetch_error, reason})
+          {:error, reason}
+      end
+    end
+
+    defp pop_fetch_error(config) do
+      if fetch_errors_agent = config[:fetch_errors_agent] do
+        Agent.get_and_update(fetch_errors_agent, fn
+          [reason | rest] -> {reason, rest}
+          [] -> {nil, []}
+        end)
+      end
+    end
+
+    defp do_fetch(topic, partition, offset, config) do
       n_messages = config[:max_bytes]
 
       messages =
@@ -657,6 +677,89 @@ defmodule BroadwayKafka.ProducerTest do
     stop_broadway(pid)
   end
 
+  test "retry fetch on retriable errors without crashing the producer" do
+    {:ok, message_server} = MessageServer.start_link()
+
+    {:ok, fetch_errors_agent} =
+      Agent.start_link(fn -> [:kafka_storage_error, :not_leader_or_follower] end)
+
+    {:ok, pid} = start_broadway(message_server, fetch_errors_agent: fetch_errors_agent)
+
+    producer = get_producer(pid)
+    producer_pid = Process.whereis(producer)
+
+    log =
+      capture_log(fn ->
+        put_assignments(producer, [[topic: "topic", partition: 0]])
+        MessageServer.push_messages(message_server, 1..5, topic: "topic", partition: 0)
+
+        assert_receive {:fetch_error, :kafka_storage_error}
+        assert_receive {:fetch_error, :not_leader_or_follower}
+
+        for msg <- 1..5 do
+          assert_receive {:message_handled, %{data: ^msg, partition: 0}}
+        end
+      end)
+
+    assert log =~ "Retriable error while fetching records from Kafka"
+    assert log =~ ":kafka_storage_error"
+    assert log =~ ":not_leader_or_follower"
+
+    assert Process.alive?(producer_pid)
+
+    stop_broadway(pid)
+  end
+
+  test "raise when retriable fetch errors persist after retries are exhausted" do
+    {:ok, message_server} = MessageServer.start_link()
+
+    {:ok, fetch_errors_agent} =
+      Agent.start_link(fn -> List.duplicate(:kafka_storage_error, 4) end)
+
+    {:ok, pid} = start_broadway(message_server, fetch_errors_agent: fetch_errors_agent)
+
+    producer = get_producer(pid)
+    producer_pid = Process.whereis(producer)
+    ref = Process.monitor(producer_pid)
+
+    log =
+      capture_log(fn ->
+        put_assignments(producer, [[topic: "topic", partition: 0]])
+        MessageServer.push_messages(message_server, 1..5, topic: "topic", partition: 0)
+
+        assert_receive {:DOWN, ^ref, :process, ^producer_pid, _reason}
+      end)
+
+    assert log =~ "cannot fetch records from Kafka"
+    assert log =~ ":kafka_storage_error"
+
+    stop_broadway(pid)
+  end
+
+  test "raise on non-retriable fetch errors without retrying" do
+    {:ok, message_server} = MessageServer.start_link()
+    {:ok, fetch_errors_agent} = Agent.start_link(fn -> [:unknown_server_error] end)
+    {:ok, pid} = start_broadway(message_server, fetch_errors_agent: fetch_errors_agent)
+
+    producer = get_producer(pid)
+    producer_pid = Process.whereis(producer)
+    ref = Process.monitor(producer_pid)
+
+    log =
+      capture_log(fn ->
+        put_assignments(producer, [[topic: "topic", partition: 0]])
+        MessageServer.push_messages(message_server, 1..5, topic: "topic", partition: 0)
+
+        assert_receive {:DOWN, ^ref, :process, ^producer_pid, _reason}
+      end)
+
+    refute log =~ "Retriable error while fetching records from Kafka"
+    assert log =~ "cannot fetch records from Kafka"
+    assert log =~ ":unknown_server_error"
+
+    stop_broadway(pid)
+  end
+
   defp start_broadway(message_server, opts \\ []) do
     producers_concurrency = Keyword.get(opts, :producers_concurrency, 1)
     processors_concurrency = Keyword.get(opts, :processors_concurrency, 1)
@@ -688,6 +791,8 @@ defmodule BroadwayKafka.ProducerTest do
                offset_commit_on_ack: false,
                begin_offset: :assigned,
                ack_raises_on_offset: ack_raises_on_offset,
+               fetch_errors_agent: Keyword.get(opts, :fetch_errors_agent),
+               fetch_retry_backoff_ms: 0,
                shared_client: opts[:shared_client] || false,
                child_specs: opts[:child_specs] || []
              ]},


### PR DESCRIPTION
We're using broadway_kafka with [WarpStream](https://www.warpstream.com/). One of the errors that WarpStream frequently returns on connection bleeps and other things like that is a "storage error"; WarpStream uses that as a blanket error for something that can be retried because Kafka marks that error as retryable. 

broadway_kafka doesn't really deal with retryable errors, so this PR attempts to do that. 

There's an alternative implementation that doesn't block the producer based on sending messages to the producer itself on an interval, but this is simple enough and might be good enough to start.
