### PR TITLE
Use docs from nimble_options schema

### DIFF
--- a/lib/broadway_kafka/producer.ex
+++ b/lib/broadway_kafka/producer.ex
@@ -7,145 +7,15 @@ defmodule BroadwayKafka.Producer do
   [Consumer API](https://kafka.apache.org/documentation.html#consumerapi) using the
   [:brod](https://github.com/klarna/brod/) client.
 
+
   ## Options
 
-    * `:hosts` - Required. A list of host and port tuples or a single string of comma
-      separated HOST:PORT pairs to use for establishing the initial connection to Kafka,
-      e.g. [localhost: 9092]. Examples:
+  #{NimbleOptions.docs(BroadwayKafka.ProducerOptions.schema())}
 
-          # Keyword
-          ["kafka-vm1": 9092, "kafka-vm2": 9092, "kafka-vm3": 9092]
-
-          # List of tuples
-          [{"kafka-vm1", 9092}, {"kafka-vm2", 9092}, {"kafka-vm3", 9092}]
-
-          # String
-          "kafka-vm1:9092,kafka-vm2:9092,kafka-vm3:9092"
-
-    * `:group_id` - Required. A unique string that identifies the consumer group the producer
-      will belong to.
-
-    * `:topics` - Required. A list of topics that the producer will subscribe to.
-
-    * `:receive_interval` - Optional. The duration (in milliseconds) for which the producer
-      waits before making a request for more messages. Default is 2000 (2 seconds).
-
-    * `:offset_commit_on_ack` - Optional. Tells Broadway to send or not an offset commit
-      request after each acknowledgement. Default is `true`. Setting this value to `false` can
-      increase performance since commit requests will respect the `:offset_commit_interval_seconds`
-      option. However, setting long commit intervals might lead to a large number of duplicated
-      records to be processed after a server restart or connection loss. If that's the case, make
-      sure your logic is idempotent when consuming records to avoid inconsistencies. Also, bear
-      in mind the the negative performance impact might be insignificant if you're using batchers
-      since only one commit request will be performed per batch.
-
-    * `:offset_reset_policy` - Optional. Defines the offset to be used when there's no initial
-      offset in Kafka or if the current offset has expired. Possible values are `:earliest`,
-      `:latest` or {:timestamp, timestamp} (in milliseconds). Default is `:latest`.
-
-    * `:begin_offset` - Optional. Defines how to get the initial offset for the consumers.
-      The possible values are `:assigned` or `:reset`. When set to `:assigned` the starting offset will be the
-      ones returned in the kafka partition assignments (the lastest committed offsets for the consumer group).
-      When set to `:reset`, the starting offset will be dictated by the `:offset_reset_policy` option, either
-      starting from the `:earliest` or the `:latest` offsets of the topic. Default is `:assigned`.
-
-    * `:shared_client` - Optional. When false, it starts one client per producer.
-      When true, it starts a single shared client across all producers (which may reduce
-      memory/resource usage). May cause severe performance degradation, see
-      ["Shared Client Performance"](#module-shared-client-performance) for details. Default is `false`.
-
-    * `:group_config` - Optional. A list of options used to configure the group
-      coordinator. See the ["Group config options"](#module-group-config-options) section below for a list of all available
-      options.
-
-    * `:fetch_config` - Optional. A list of options used when fetching messages. See the
-      ["Fetch config options"](#module-fetch-config-options) section below for a list of all available options.
-
-    * `:client_config` - Optional. A list of options used when creating the client. See the
-      ["Client config options"](#module-client-config-options) section below for a list of all available options.
-
-  ## Group config options
-
-  The available options that will be passed to `:brod`'s group coordinator.
-
-    * `:offset_commit_interval_seconds` - Optional. The time interval between two
-       OffsetCommitRequest messages. Default is 5.
-
-    * `:rejoin_delay_seconds` - Optional. Delay in seconds before rejoining the group. Default is 1.
-
-    * `:session_timeout_seconds` - Optional. Time in seconds the group coordinator broker waits
-      before considering a member 'down' if no heartbeat or any kind of request is received.
-      A group member may also consider the coordinator broker 'down' if no heartbeat response
-      is received in the past N seconds. Default is 30 seconds.
-
-    * `:heartbeat_rate_seconds` - Optional. Time in seconds for member to 'ping' group coordinator.
-      Heartbeats are used to ensure that the consumer's session stays active and
-      to facilitate rebalancing when new consumers join or leave the group.
-      The value must be set lower than `:session_timeout_seconds`, typically equal to or lower than 1/3 of that value.
-      It can be adjusted even lower to control the expected time for normal rebalances. Default is 5 seconds.
-
-    * `:rebalance_timeout_seconds` - Optional. Time in seconds for each worker to join the group once a rebalance has begun.
-      If the timeout is exceeded, then the worker will be removed from the group, which will cause offset commit failures. Default is 30.
-
-  ## Fetch config options
-
-  The available options that will be internally passed to `:brod.fetch/5`.
-
-    * `:min_bytes` - Optional. The minimum amount of data to be fetched from the server.
-      If not enough data is available the request will wait for that much data to accumulate
-      before answering. Default is 1 byte. Setting this value greater than 1 can improve
-      server throughput a bit at the cost of additional latency.
-
-    * `:max_bytes` - Optional. The maximum amount of data to be fetched at a time from a single
-      partition. Default is 1048576 (1 MiB). Setting greater values can improve server
-      throughput at the cost of more memory consumption.
-
-    * `:max_wait_time` - Optional. Time in millisecond. Max number of milliseconds allowed for the broker to collect
-    `min_bytes` of messages in fetch response. Default is 1000ms.
-
-  ## Client config options
-
-  The available options that will be internally passed to `:brod.start_client/3`.
-
-    * `:client_id_prefix` - Optional. A string that will be used to build the client id passed to `:brod`. The example
-    value `client_id_prefix: :"\#{Node.self()} -"` would generate the following connection log from our integration
-    tests:
-
-          20:41:37.717 [info]      :supervisor: {:local, :brod_sup}
-          :started: [
-            pid: #PID<0.286.0>,
-            id: :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
-            mfargs: {:brod_client, :start_link,
-             [
-               [localhost: 9092],
-               :"nonode@nohost - Elixir.BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client",
-               [client_id_prefix: :"nonode@nohost - "]
-             ]},
-            restart_type: {:permanent, 10},
-            shutdown: 5000,
-            child_type: :worker
-          ]
-
-    * `:sasl` - Optional. A a tuple of mechanism which can be `:plain`, `:scram_sha_256` or `:scram_sha_512`, username and password. See the `:brod`'s
-    [`Authentication Support`](https://github.com/klarna/brod#authentication-support) documentation
-    for more information. Default is no sasl options.
-
-    * `:ssl` - Optional. A boolean or a list of options to use when connecting via SSL/TLS. See the
-    [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option) documentation
-    for more information. Default is no ssl options.
-
-    * `:connect_timeout` - Optional. Time in milliseconds to be used as a timeout for `:brod`'s communication with Kafka.
-    Default is to use `:brod`'s default timeout which is currently 5 seconds.
-
-    * `:request_timeout` - Optional. Time in milliseconds to be used as a timeout for waiting response from Kafka.
-    Default is to use `:brod`'s default timeout which is currently 240 seconds.
-
-    * `:extra_sock_opts` - Optional. `gen_tcp` socket options. [More info](https://www.erlang.org/doc/man/gen_tcp.html#type-option).
-    Set to `[:inet6]` if your Kafka broker uses IPv6.
-
-  > **Note**: Currently, Broadway does not support all options provided by `:brod`. If you
-  have a scenario where you need any extra option that is not listed above, please open an
-  issue, so we can consider adding it.
+  > #### `:brod` Option Support {: .info}
+  > Currently, Broadway does not support all options provided by `:brod`. If you
+  > have a scenario where you need any extra option that is not listed above, please open an
+  > issue, so we can consider adding it.
 
   ## Example
 

--- a/lib/broadway_kafka/producer_options.ex
+++ b/lib/broadway_kafka/producer_options.ex
@@ -4,36 +4,46 @@ defmodule BroadwayKafka.ProducerOptions do
   group_config_schema = [
     offset_commit_interval_seconds: [
       type: :pos_integer,
+      default: 5,
       doc: """
-      The time in seconds between two offset commit requests.
+      The time *in seconds* between two `OffsetCommitRequest` messages.
       """
     ],
     rejoin_delay_seconds: [
       type: :non_neg_integer,
+      default: 1,
       doc: """
-      The delay in seconds before rejoining the group.
+      The delay *in seconds* before rejoining the group.
       """
     ],
     session_timeout_seconds: [
       type: :pos_integer,
+      default: 30,
       doc: """
-      The time in seconds that the group coordinator waits before it considers a member down.
-      A group member may also consider the coordinator down if it receives no heartbeat response
-      within this time.
+      The time *in seconds* that the group coordinator waits before it considers a member "down"
+      (if no heartbeat or any kind of request is received). A group member may also consider
+      the coordinator "down" if it receives no heartbeat response within this time.
       """
     ],
     heartbeat_rate_seconds: [
       type: :pos_integer,
+      default: 5,
       doc: """
-      The time in seconds between heartbeats sent to the group coordinator. This must be less
-      than `:session_timeout_seconds` and is often no more than one third of that value.
+      The time *in seconds* between heartbeats ("ping" requests) sent to the group coordinator.
+      Heartbeats are used to ensure that the consumer's session stays active and
+      to facilitate rebalancing when new consumers join or leave the group.
+      The value must be set lower than `:session_timeout_seconds`, typically equal to or lower
+      than ⅓ of that value. It can be adjusted even lower to control the expected time
+      for normal rebalances.
       """
     ],
     rebalance_timeout_seconds: [
       type: :pos_integer,
+      default: 30,
       doc: """
-      The time in seconds that each worker has to join the group after a rebalance starts.
-      If a worker takes longer, Kafka removes it from the group.
+      The time *in seconds* that each worker has to join the group after a rebalance starts.
+      If the timeout is exceeded, then the worker will be removed from the group,
+      which will cause offset commit failures.
       """
     ]
   ]
@@ -41,13 +51,17 @@ defmodule BroadwayKafka.ProducerOptions do
   fetch_config_schema = [
     min_bytes: [
       type: :pos_integer,
+      default: 1,
       doc: """
-      The least amount of data that the server should return. The request waits until this much
-      data is ready. A larger value may improve throughput at the cost of more delay.
+      The minimum amount of data to be fetched from the server.
+      If not enough data is available the request will wait for that much data to accumulate
+      before answering. Setting this value greater than `1` can improve
+      server throughput a bit at the cost of additional latency.
       """
     ],
     max_bytes: [
       type: :pos_integer,
+      default: _1mb = 1024 * 1024,
       doc: """
       The most data to fetch from one partition at a time. A larger value may improve throughput
       at the cost of more memory use.
@@ -55,8 +69,9 @@ defmodule BroadwayKafka.ProducerOptions do
     ],
     max_wait_time: [
       type: :pos_integer,
+      default: to_timeout(second: 1),
       doc: """
-      The most time, in milliseconds, that the broker may wait for `:min_bytes` of data.
+      The most time (in millisecond) that the broker may wait for `:min_bytes` of data.
       """
     ]
   ]
@@ -76,28 +91,33 @@ defmodule BroadwayKafka.ProducerOptions do
            {:custom, __MODULE__, :validate_sasl_tuple, []}
          ]},
       doc: """
-      The SASL settings. Pass `{mechanism, username, password}` or `{mechanism, path}`, where
-      `mechanism` is `:plain`, `:scram_sha_256`, or `:scram_sha_512`. You may also pass
-      `{:callback, module, options}` for a SASL plug-in. Defaults to `:undefined`.
+      A tuple of "mechanism" (`:plain`, `:scram_sha_256`, or `:scram_sha_512`),
+      username, and password. See `:brod`'s
+      [`Authentication Support`](https://github.com/kafka4beam/brod#authentication-support)
+      documentation for more information. You may also pass `{:callback, module, options}`
+      for a SASL plug-in. Set this to `:undefined` to disable SASL.
       """
     ],
     ssl: [
       type: {:or, [:boolean, :keyword_list]},
       doc: """
-      A boolean or a keyword list of SSL/TLS client options.
-      See `t::ssl.tls_client_option/0`.
+      A boolean or a keyword list of SSL/TLS client options. See the
+      [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option)
+      documentation for more information.
       """
     ],
     connect_timeout: [
       type: :pos_integer,
       doc: """
-      The time, in milliseconds, allowed for a connection to Kafka.
+      The time (in milliseconds) allowed for a connection to Kafka. Default is what
+      `:brod` defaults to (5s at the time of writing).
       """
     ],
     request_timeout: [
       type: {:custom, __MODULE__, :validate_integer_gte, [:request_timeout, 1_000]},
       doc: """
-      The time, in milliseconds, allowed for a response from Kafka. It must be at least `1_000`.
+      The time (in milliseconds) allowed for a response from Kafka. It must be at least `1_000`.
+      Default is to use `:brod`'s default timeout which is currently 4 minutes (`240_000`).
       """
     ],
     query_api_versions: [
@@ -110,15 +130,15 @@ defmodule BroadwayKafka.ProducerOptions do
     extra_sock_opts: [
       type: {:list, :any},
       doc: """
-      Extra `gen_tcp` socket options. For example, use `[:inet6]` for an IPv6 broker.
-      Defaults to `[]`.
+      Extra `gen_tcp` socket options. [More info](https://www.erlang.org/doc/man/gen_tcp.html#type-option).
+      Set to `[:inet6]` if your Kafka broker uses IPv6.
       """
     ],
     allow_topic_auto_creation: [
       type: :boolean,
       doc: """
       Whether `:brod` may send metadata requests that can create a topic when the broker allows
-      automatic topic creation. Defaults to `true`.
+      automatic topic creation.
       """
     ]
   ]
@@ -129,18 +149,15 @@ defmodule BroadwayKafka.ProducerOptions do
       required: true,
       doc: """
       A list of host and port pairs, or one string of comma-separated `HOST:PORT` pairs, used
-      to make the first connection to Kafka. For example:
-
-          [localhost: 9092]
-          [{"kafka-vm1", 9092}, {"kafka-vm2", 9092}]
-          "kafka-vm1:9092,kafka-vm2:9092"
+      to make the first connection to Kafka. For example: `[localhost: 9092]`,
+      `[{"kafka-vm1", 9092}, {"kafka-vm2", 9092}]`, `"kafka-vm1:9092,kafka-vm2:9092"`.
       """
     ],
     group_id: [
       type: {:custom, __MODULE__, :validate_nonempty_string, [:group_id]},
       required: true,
       doc: """
-      A non-empty string that names the consumer group that the producer will join.
+      A (non-empty) unique string that identifies the consumer group that the producer will join.
       """
     ],
     topics: [
@@ -154,7 +171,8 @@ defmodule BroadwayKafka.ProducerOptions do
       type: :non_neg_integer,
       default: 2_000,
       doc: """
-      The time, in milliseconds, that the producer waits before asking for more messages.
+      The duration (in milliseconds) that the producer waits before making
+      a request for more messages.
       """
     ],
     reconnect_timeout: [
@@ -166,10 +184,14 @@ defmodule BroadwayKafka.ProducerOptions do
       type: :boolean,
       default: true,
       doc: """
-      Whether Broadway sends an offset commit request after each acknowledgement. Setting this
-      to `false` may improve throughput because commits will follow
-      `:offset_commit_interval_seconds`. A long commit interval may cause more records to run
-      again after a restart or lost connection, so message handling should be safe to repeat.
+      Tells Broadway to send or not an offset commit request after each acknowledgement.
+      Setting this value to `false` can increase performance since commit requests will
+      respect the `:offset_commit_interval_seconds` option. However, setting long commit
+      intervals might lead to a large number of duplicated records to be processed after
+      a server restart or connection loss. If that's the case, make sure your logic is
+      **idempotent** when consuming records to avoid inconsistencies. Also, bear
+      in mind the the negative performance impact might be insignificant if you're using
+      batchers since only one commit request will be performed per batch.
       """
     ],
     offset_reset_policy: [
@@ -178,29 +200,35 @@ defmodule BroadwayKafka.ProducerOptions do
       doc: """
       The offset to use when Kafka has no saved offset or the saved offset has expired. Use
       `:earliest`, `:latest`, or `{:timestamp, timestamp}`, where `timestamp` is a non-negative
-      time in milliseconds. Defaults to `:latest`.
+      time in milliseconds.
       """
     ],
     begin_offset: [
       type: {:in, [:assigned, :reset]},
       default: :assigned,
       doc: """
-      How consumers choose their first offset. `:assigned` uses the offsets from the Kafka
-      partition assignments. `:reset` uses `:offset_reset_policy`. Defaults to `:assigned`.
+      How consumers choose their first offset. When set to `:assigned`, the starting offset
+      will be the one returned in the Kafka partition assignments (the latest committed
+      offsets for the consumer group). When set to `:reset`, the starting offset will be
+      dictated by the `:offset_reset_policy` option, either starting from the `:earliest`
+      or the `:latest` offsets of the topic.
       """
     ],
     shared_client: [
       type: :boolean,
       default: false,
       doc: """
-      Whether all producers share one client. Sharing can cut memory and other resource use,
-      but it may cause a large drop in throughput.
+      When `false`, it starts one `:brod` client per producer. When `true`, it starts a
+      single shared `:brod` client across all producers (which may reduce
+      memory/resource usage). May cause severe performance degradation, see
+      ["Shared Client Performance"](#module-shared-client-performance) for details.
       """
     ],
     group_config: [
       type: :keyword_list,
       default: [],
       keys: group_config_schema,
+      subsection: "### Group config",
       doc: """
       Options passed to `:brod`'s group coordinator.
       """
@@ -209,14 +237,17 @@ defmodule BroadwayKafka.ProducerOptions do
       type: :keyword_list,
       default: [],
       keys: fetch_config_schema,
+      subsection: "### Fetch config",
       doc: """
-      Options passed to `:brod.fetch/5` when it fetches messages.
+      The available options to configure how messages are fetched. Unless noted
+      otherwise, they are internally passed to `:brod.fetch/5`.
       """
     ],
     client_config: [
       type: :keyword_list,
       default: [],
       keys: client_config_schema,
+      subsection: "### Client config",
       doc: """
       Options passed to `:brod.start_client/3` when it starts a client.
       """

--- a/lib/broadway_kafka/producer_options.ex
+++ b/lib/broadway_kafka/producer_options.ex
@@ -69,7 +69,7 @@ defmodule BroadwayKafka.ProducerOptions do
     ],
     max_wait_time: [
       type: :pos_integer,
-      default: to_timeout(second: 1),
+      default: 1_000,
       doc: """
       The most time (in millisecond) that the broker may wait for `:min_bytes` of data.
       """

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -261,11 +261,11 @@ defmodule BroadwayKafka.BrodClientTest do
       assert_opt_error(opts, "expected :max_wait_time to be a positive integer, got: :an_atom")
 
       {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(@opts)
-      assert not Map.has_key?(fetch_config, :max_wait_time)
+      assert Map.has_key?(fetch_config, :max_wait_time)
 
-      opts = put_in(@opts, [:fetch_config, :max_wait_time], 3)
+      opts = put_in(@opts, [:fetch_config, :max_wait_time], 3000)
       {:ok, [], %{fetch_config: fetch_config}} = BrodClient.init(opts)
-      assert fetch_config[:max_wait_time] == 3
+      assert fetch_config[:max_wait_time] == 3000
     end
 
     test ":client_id_prefix is an optional atom value" do
@@ -406,24 +406,6 @@ defmodule BroadwayKafka.BrodClientTest do
       opts = put_in(@opts, [:client_config, :query_api_versions], false)
 
       assert {:ok, [], %{client_config: [query_api_versions: false]}} = BrodClient.init(opts)
-    end
-
-    test ":allow_topic_auto_creation is an optional positive boolean" do
-      opts = put_in(@opts, [:client_config, :allow_topic_auto_creation], "false")
-
-      assert_opt_error(
-        opts,
-        "expected :allow_topic_auto_creation to be a boolean, got: \"false\""
-      )
-
-      opts = put_in(@opts, [:client_config, :allow_topic_auto_creation], false)
-
-      assert {:ok, [],
-              %{
-                client_config: [
-                  allow_topic_auto_creation: false
-                ]
-              }} = BrodClient.init(opts)
     end
 
     test ":shared_client is an optional boolean" do

--- a/test/integration/consume_test.exs
+++ b/test/integration/consume_test.exs
@@ -27,7 +27,6 @@ defmodule BroadwayKafka.ConsumerTest do
   """
 
   use ExUnit.Case
-  require Logger
 
   @moduletag :integration
 
@@ -289,7 +288,6 @@ defmodule BroadwayKafka.ConsumerSharedClientTest do
   """
 
   use ExUnit.Case
-  require Logger
 
   @moduletag :integration
 


### PR DESCRIPTION
@slashmili this is the follow up from #161: we now can use nimble_options to generate docs for these options. 🙃 