### PR TITLE
Update Elixir and OTP versions (1.16+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.12.3-erlang-24.3.4.9-alpine-3.17.7"
-          - "1.14.3-erlang-25.3-alpine-3.17.2"
+          - "1.16.3-erlang-24.3.4.2-alpine-3.20.8"
+          - "1.16.3-erlang-26.2.5.11-alpine-3.23.3"
     steps:
       - uses: actions/checkout@v4
       - name: Download released earthly
@@ -33,10 +33,10 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.12
+              elixir: 1.16
               otp: 24
           - pair:
-              elixir: 1.15
+              elixir: 1.16
               otp: 26
             lint: lint
     steps:

--- a/Earthfile
+++ b/Earthfile
@@ -2,13 +2,13 @@ VERSION  0.7
 
 all:
     BUILD \
-        --build-arg ELIXIR_BASE=1.11.3-erlang-23.2.5-alpine-3.16.0 \
-        --build-arg ELIXIR_BASE=1.14.3-erlang-25.3-alpine-3.17.2 \
+        --build-arg ELIXIR_BASE=1.16.3-erlang-24.3.4.2-alpine-3.20.8 \
+        --build-arg ELIXIR_BASE=1.16.3-erlang-26.2.5.11-alpine-3.23.3 \
         +integration-test
 
 
 setup-base:
-    ARG ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0
+    ARG ELIXIR_BASE=1.16.3-erlang-24.3.4.2-alpine-3.20.8
     FROM hexpm/elixir:$ELIXIR_BASE
     RUN apk add --no-progress --update build-base
     RUN mix local.rebar --force

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule BroadwayKafka.MixProject do
     [
       app: :broadway_kafka,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.16",
       name: "BroadwayKafka",
       description: @description,
       start_permanent: Mix.env() == :prod,
@@ -27,7 +27,7 @@ defmodule BroadwayKafka.MixProject do
   defp deps do
     [
       {:broadway, "~> 1.0"},
-      {:brod, "~> 3.16 or ~> 4.0"},
+      {:brod, "~> 4.0"},
       {:nimble_options, "~> 0.3 or ~> 1.0"},
       {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:ex_doc, ">= 0.19.0", only: :docs}

--- a/test/brod_client_test.exs
+++ b/test/brod_client_test.exs
@@ -501,7 +501,7 @@ defmodule BroadwayKafka.BrodClientTest do
     @behaviour :kpro_auth_backend
 
     @impl true
-    def auth(_host, _sock, _mod, _client_id, _timeout, _sasl_opts = {}) do
+    def auth(_host, _sock, _handshake_vsn, _mod, _client_id, _timeout, _sasl_opts = {}) do
       :ok
     end
   end


### PR DESCRIPTION
I think we could shed some tech debt here now that the earliest supported Elixir version is 1.16. I don't think there's a strong reason to keep brod 3.x around either. Thoughts?